### PR TITLE
TSAPPS-177 Read file with offers

### DIFF
--- a/di/di.go
+++ b/di/di.go
@@ -8,6 +8,7 @@ import (
 	"ts/externalAPI/rest"
 	"ts/externalAPI/tradeshiftAPI"
 	"ts/mapping"
+	"ts/offerImport/offerReader"
 	"ts/ontology"
 	"ts/ontologyValidator"
 	"ts/reports"
@@ -30,6 +31,7 @@ var diConfig = []entry{
 	{constructor: adapters.NewFileManager},
 	{constructor: adapters.NewHandler},
 	{constructor: ontology.NewRulesHandler},
+	{constructor: offerReader.NewOfferReader},
 	{constructor: ontologyValidator.NewValidator},
 	{constructor: reports.NewReportsHandler},
 	{constructor: rest.NewRestClient},

--- a/offerImport/offerReader/offerReader.go
+++ b/offerImport/offerReader/offerReader.go
@@ -1,0 +1,83 @@
+package offerReader
+
+import (
+	"fmt"
+	"go.uber.org/dig"
+	"log"
+	"ts/adapters"
+)
+
+type OfferReader struct {
+	fileManager *adapters.FileManager
+	reader      adapters.HandlerInterface
+}
+
+type RawOffer struct {
+	OfferID   string
+	Receiver  string
+	Contract  string
+	ValidFrom string
+	ExpiresAt string
+	Countries string
+}
+
+type Deps struct {
+	dig.In
+	Reader      adapters.HandlerInterface
+	FileManager *adapters.FileManager
+}
+
+func NewOfferReader(deps Deps) *OfferReader {
+	return &OfferReader{
+		reader:      deps.Reader,
+		fileManager: deps.FileManager,
+	}
+}
+
+func (o *OfferReader) UploadOffers(path string) []RawOffer {
+	ext := o.fileManager.GetFileType(path)
+	o.reader.Init(ext)
+	parsedRaws := o.reader.Parse(path)
+	actualHeader := o.reader.GetHeader()
+	header, err := processHeader(actualHeader)
+	if err != nil {
+		log.Fatalf("failed to upload rules: %v", err)
+	}
+	or := processOffers(parsedRaws, header)
+	log.Printf("Offers upload finished.")
+	return or
+
+}
+
+func processOffers(raws []map[string]interface{}, header *RawHeader) []RawOffer {
+	res := make([]RawOffer, len(raws))
+	for i, item := range raws {
+		offer := RawOffer{
+			OfferID:  fmt.Sprintf("%v", item[header.OfferID]),
+			Receiver: fmt.Sprintf("%v", item[header.Receiver]),
+		}
+		if header.ContractID != "" {
+			offer.Contract = fmt.Sprintf("%v", item[header.ContractID])
+		}
+		if header.ValidFrom != "" {
+			offer.ValidFrom = fmt.Sprintf("%v", item[header.ValidFrom])
+		}
+		if header.ExpiresAt != "" {
+			offer.ExpiresAt = fmt.Sprintf("%v", item[header.ExpiresAt])
+		}
+		if header.Countries != "" {
+			offer.Countries = fmt.Sprintf("%v", item[header.Countries])
+		}
+		res[i] = offer
+	}
+
+	return res
+}
+
+func processHeader(parsedHeader []string) (*RawHeader, error) {
+	resHeader := NewHeader(parsedHeader)
+	if err := resHeader.ValidateHeader(); err != nil {
+		return nil, err
+	}
+	return resHeader, nil
+}

--- a/offerImport/offerReader/rawHeader.go
+++ b/offerImport/offerReader/rawHeader.go
@@ -1,0 +1,55 @@
+package offerReader
+
+import (
+	"fmt"
+	"ts/utils"
+)
+
+const (
+	defaultOfferID    = "Offer"
+	defaultReceiver   = "Receiver"
+	defaultContractID = "Contract ID"
+	defaultValidFrom  = "Valid From"
+	defaultExpiresAt  = "ExpiresAt"
+	defaultCountries  = "Countries"
+)
+
+type RawHeader struct {
+	OfferID    string
+	Receiver   string
+	ContractID string
+	ValidFrom  string
+	ExpiresAt  string
+	Countries  string
+}
+
+func NewHeader(input []string) *RawHeader {
+	var newHeader RawHeader
+	for _, columnLabel := range input {
+		//required
+		trimmedColumnLabel := utils.TrimAll(columnLabel)
+		switch trimmedColumnLabel {
+		case utils.TrimAll(defaultOfferID):
+			newHeader.OfferID = columnLabel
+		case utils.TrimAll(defaultReceiver):
+			newHeader.Receiver = columnLabel
+		//unrequired
+		case utils.TrimAll(defaultContractID):
+			newHeader.ContractID = columnLabel
+		case utils.TrimAll(defaultValidFrom):
+			newHeader.ValidFrom = columnLabel
+		case utils.TrimAll(defaultExpiresAt):
+			newHeader.ExpiresAt = columnLabel
+		case utils.TrimAll(defaultCountries):
+			newHeader.Countries = columnLabel
+		}
+	}
+	return &newHeader
+}
+
+func (rh *RawHeader) ValidateHeader() error {
+	if rh.OfferID == "" || rh.Receiver == "" {
+		return fmt.Errorf("offers file does not contains all requiered fields: actual [OfferID: %v, Receiver: %v]", rh.OfferID, rh.Receiver)
+	}
+	return nil
+}


### PR DESCRIPTION
List of offers to be import should be read from csv file with 2 required columns and stored as object
- Offers (with offer names)
- Receiver (with receiver ID)
Input file validation out of MVP scope