### PR TITLE
TSAPPS-216 [hotfix]Fix header init 

### DIFF
--- a/adapters/handler.go
+++ b/adapters/handler.go
@@ -52,6 +52,7 @@ func (h *Handler) Write(filepath string, data [][]string) {
 
 func (h *Handler) Parse(filePath string) []map[string]interface{} {
 	res, err := h.Adapter.Parse(filePath)
+	h.header = h.Adapter.GetHeader()
 	if err != nil {
 		log.Fatalf("failed to Read file %v: %v", filePath, err)
 	}

--- a/offerImport/offerReader/offerReader.go
+++ b/offerImport/offerReader/offerReader.go
@@ -41,7 +41,7 @@ func (o *OfferReader) UploadOffers(path string) []RawOffer {
 	actualHeader := o.reader.GetHeader()
 	header, err := processHeader(actualHeader)
 	if err != nil {
-		log.Printf("failed to upload rules: %v", err)
+		log.Printf("failed to upload offers: %v", err)
 		return nil
 	}
 	or := processOffers(parsedRaws, header)

--- a/prepareImport/prepareImportHandler.go
+++ b/prepareImport/prepareImportHandler.go
@@ -47,7 +47,6 @@ func NewPrepareImportHandler(deps Deps) *Handler {
 func (h *Handler) Run() {
 	files := getXLSXFiles(h.sourcePath)
 	if len(files) == 0 {
-		log.Printf("no xlsx files for imports are specified in %v", h.sourcePath)
 		return
 	}
 


### PR DESCRIPTION
Fix bug. Header should be used by adapter's object users, so it should be inited for adapter