### PR TITLE
TSAPPS-217 Skip offers with empty buyerID and OfferID

### DIFF
--- a/offerImport/importHandler/importOffersToTradeshift.go
+++ b/offerImport/importHandler/importOffersToTradeshift.go
@@ -18,12 +18,26 @@ func NewImportOfferHandler(deps Deps) ImportOfferInterface {
 }
 
 func (i *ImportOfferHandler) ImportOffers(offers []offerReader.RawOffer) {
-	for _, item := range offers {
-		_, err := i.ImportOffer(item.Offer, item.Receiver)
+	for _, offer := range offers {
+		if err := validateOffer(offer); err != nil {
+			log.Printf("failed to import offer \"%v\". Reason:  %v", offer, err)
+			break
+		}
+		_, err := i.ImportOffer(offer.Offer, offer.Receiver)
 		if err != nil {
-			log.Printf("failed to import offer \"%v\". Reason:  %v", item.Offer, err)
+			log.Printf("failed to import offer \"%v\". Reason:  %v", offer.Offer, err)
 		}
 	}
+}
+
+func validateOffer(offer offerReader.RawOffer) error {
+	if offer.Offer == "" {
+		return fmt.Errorf("offer name should be defined")
+	}
+	if offer.Receiver == "" {
+		return fmt.Errorf("offer receiver should be defined")
+	}
+	return nil
 }
 
 func (i *ImportOfferHandler) ImportOffer(offerName string, buyerID string) (Status, error) {
@@ -32,7 +46,6 @@ func (i *ImportOfferHandler) ImportOffer(offerName string, buyerID string) (Stat
 		return Failed, err
 	}
 	if !isFound {
-		log.Print("buyer \"%v\" was not found", buyerID)
 		return BuyerNotFound, nil
 	}
 

--- a/offerImport/offerReader/offerReader_test.go
+++ b/offerImport/offerReader/offerReader_test.go
@@ -1,0 +1,81 @@
+package offerReader
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_processOffer(t *testing.T) {
+	type args struct {
+		header *RawHeader
+		item   map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want *RawOffer
+	}{
+		{
+			name: "positive: row without required fields should be skipped",
+			args: args{
+				header: &RawHeader{
+					Offer:    "Offers",
+					Receiver: "Countries",
+				},
+				item: map[string]interface{}{
+					"Offers":    nil,
+					"Receiver":  "",
+					"Countries": "US",
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := processOffer(tt.args.header, tt.args.item); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("processOffer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isEmptyRow(t *testing.T) {
+	type args struct {
+		row map[string]interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "positive: row without values should be considered as empty",
+			args: args{
+				row: map[string]interface{}{
+					"Offer":    "",
+					"Receiver": nil,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "positive: row with part of values should be considered as not empty",
+			args: args{
+				row: map[string]interface{}{
+					"Offer":      "",
+					"Receiver":   nil,
+					"ContractID": "123",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isEmptyRow(tt.args.row); got != tt.want {
+				t.Errorf("isEmptyRow() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
File parsed from XLSX may contain empty strings with empty required fields.
Such rows should be skipped
And buyerID and offerItem should be checked for non-empty value before API calls with it's values