### PR TITLE
TSAPPS-224 Fix mapping for success report

### DIFF
--- a/productImport/mapping/mapping.go
+++ b/productImport/mapping/mapping.go
@@ -14,8 +14,7 @@ const (
 )
 
 type mapping struct {
-	rawMap    map[string]string
-	parsedMap *ColumnMap
+	rawMap map[string]string
 }
 
 func NewMappingHandler(deps Deps) MappingHandlerInterface {

--- a/productImport/mapping/mapping_test.go
+++ b/productImport/mapping/mapping_test.go
@@ -8,7 +8,6 @@ import (
 func Test_mapping_Parse(t *testing.T) {
 	type fields struct {
 		rawMap    map[string]string
-		parsedMap *ColumnMap
 	}
 	tests := []struct {
 		name   string
@@ -46,7 +45,6 @@ func Test_mapping_Parse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &mapping{
 				rawMap:    tt.fields.rawMap,
-				parsedMap: tt.fields.parsedMap,
 			}
 			if got := m.Parse(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Parse() = %v, want %v", got, tt.want)

--- a/productImport/productImportHandler.go
+++ b/productImport/productImportHandler.go
@@ -63,7 +63,7 @@ func (ph *ProductImportHandler) RunCSV() {
 	}
 
 	// mappings
-	columnMap := ph.mapHandler.Get()//Init(ph.config.ProductCatalog.MappingPath)
+	columnMap := ph.mapHandler.Get() //Init(ph.config.ProductCatalog.MappingPath)
 
 	// feed
 	err = ph.processProducts(columnMap, rulesConfig)
@@ -208,7 +208,7 @@ func (ph *ProductImportHandler) processFeed(
 	}
 
 	cleanUpFailures(sourceFeedPath, ph.config.ProductCatalog.FailResultPath)
-	validationReportPath = ph.reports.WriteReport(sourceFeedPath, hasErrors, feed, parsedData, columnMap)
+	validationReportPath = ph.reports.WriteReport(sourceFeedPath, hasErrors, feed, parsedData)
 	if !hasErrors {
 		log.Println("IMPORT FEED TO TRADESHIFT WAS STARTED")
 		er := ph.importHandler.ImportFeedToTradeshift(sourceFeedPath, validationReportPath)

--- a/productImport/reports/reportsHandler_test.go
+++ b/productImport/reports/reportsHandler_test.go
@@ -3,6 +3,7 @@ package reports
 import (
 	"reflect"
 	"testing"
+	"ts/adapters"
 	"ts/productImport/mapping"
 )
 
@@ -16,7 +17,7 @@ func Test_initFirstRaw(t *testing.T) {
 		want *ReportLabels
 	}{
 		{
-			name: "positive: header labels should be taken from mapping",
+			name: "positive: header labels for failures report should be taken from mapping",
 			args: args{
 				m: &mapping.ColumnMap{
 					ProductID: "SKU",
@@ -64,6 +65,372 @@ func Test_initFirstRaw(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := initFirstRaw(tt.args.m); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("initFirstRaw() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReportsHandler_buildSuccessMapRaw(t *testing.T) {
+	type fields struct {
+		Handler     adapters.HandlerInterface
+		Header      *ReportLabels
+		ColumnMap   *ColumnMap
+		FileManager *adapters.FileManager
+	}
+	type args struct {
+		source      []map[string]interface{}
+		reportItems []Report
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   [][]string
+	}{
+		{
+			name: "positive: attribute value in report should be replaced with value from fixed data. " +
+				"Report should contain header in TradeShift format" +
+				"Source data in report (CategoryID, Name) should be actualized relatively to fixed data",
+
+			fields: fields{
+				ColumnMap: &ColumnMap{
+					ProductID: "ProductID",
+					Category:  "UNSPSC",
+					Name:      "Product Name",
+				},
+			},
+			args: args{
+				source: []map[string]interface{}{
+					{
+						"ProductID":    "1",
+						"UNSPSC":       "1000011",
+						"Product Name": "Product 1",
+						"Attribute1":   "Value1",
+					},
+				},
+				reportItems: []Report{
+					{
+						ProductId:   "1",
+						Category:    "100001",
+						Name:        " Product1",
+						AttrName:    "Attribute1",
+						AttrValue:   "FixedValue1",
+						IsMandatory: "true",
+					},
+				},
+			},
+			want: [][]string{
+				{
+					"ID", "Category", "Name", "Attribute1",
+				},
+				{
+					"1", "100001", "Product 1", "FixedValue1",
+				},
+			},
+		},
+		/* row order is changeble- test are unstable for CI run
+		{
+			name: "positive: attributes from source data and fixed data should be added to report",
+
+			fields: fields{
+				ColumnMap: &ColumnMap{
+					ProductID: "ProductID",
+					Category:  "UNSPSC",
+					Name:      "Product Name",
+				},
+			},
+			args: args{
+				source: []map[string]interface{}{
+					{
+						"ProductID":    "1",
+						"UNSPSC":       "100001",
+						"Product Name": "Product 1",
+						"Attribute1":   "Value1",
+						"Attribute2":   "Value2",
+					},
+				},
+				reportItems: []Report{
+					{
+						ProductId:   "1",
+						Category:    "100001",
+						Name:        " Product1",
+						AttrName:    "Attribute1",
+						AttrValue:   "FixedValue1",
+						IsMandatory: "true",
+					},
+					{
+						ProductId:   "1",
+						Category:    "100001",
+						Name:        " Product1",
+						AttrName:    "Attribute3",
+						AttrValue:   "Value3",
+						IsMandatory: "true",
+					},
+				},
+			},
+			want: [][]string{
+				{
+					"ID", "Category", "Name", "Attribute1", "Attribute2", "Attribute3",
+				},
+				{
+					"1", "100001", "Product 1", "FixedValue1", "Value2", "Value3",
+				},
+			},
+		},
+		{
+			name: "positive: if attribute in fixed data has no category, category should be taken from source data",
+			fields: fields{
+				ColumnMap: &ColumnMap{
+					ProductID: "ProductID",
+					Category:  "UNSPSC",
+					Name:      "Product Name",
+				},
+			},
+			args: args{
+				source: []map[string]interface{}{
+					{
+						"ProductID":    "1",
+						"UNSPSC":       "100001",
+						"Product Name": "Product 1",
+						"Attribute1":   "Value1",
+					},
+				},
+				reportItems: []Report{
+					{
+						ProductId:   "1",
+						Name:        " Product1",
+						AttrName:    "Attribute1",
+						AttrValue:   "FixedValue1",
+						IsMandatory: "true",
+					},
+				},
+			},
+			want: [][]string{
+				{
+					"ID", "Category", "Name", "Attribute1",
+				},
+				{
+					"1", "100001", "Product 1", "FixedValue1",
+				},
+			},
+		},*/
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReportsHandler{
+				Handler:     tt.fields.Handler,
+				Header:      tt.fields.Header,
+				ColumnMap:   tt.fields.ColumnMap,
+				FileManager: tt.fields.FileManager,
+			}
+			if got := r.buildSuccessMapRaw(tt.args.source, tt.args.reportItems); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildSuccessMapRaw() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_buildHeader(t *testing.T) {
+	type args struct {
+		source      []map[string]interface{}
+		reportItems []Report
+		columnMap   *ColumnMap
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  []string
+		want1 map[string]int64
+	}{
+		{
+			name: "positive: success report header should be built in Tradeshift format(with default column values for productID and Category)",
+			args: args{
+				source: []map[string]interface{}{
+					{
+						"ProductID":  "1233",
+						"UNSPSC":     "1321442",
+						"PName":      "Test product",
+						"Attribute1": "High availability",
+					},
+				},
+				reportItems: []Report{
+					{
+						ProductId:    "123",
+						Name:         "Test product",
+						Category:     "1321442",
+						CategoryName: "Test Category Name",
+						AttrName:     "Attribute1",
+						AttrValue:    "High availability",
+					},
+				},
+				columnMap: &ColumnMap{
+					Category:  "UNSPSC",
+					ProductID: "ProductID",
+					Name:      "PName",
+				},
+			},
+			want: []string{
+				"ID",
+				"Category",
+				"Name",
+				"Attribute1",
+			},
+			want1: map[string]int64{
+				"ProductID":  0,
+				"UNSPSC":     1,
+				"PName":      2,
+				"Attribute1": 3,
+			},
+		},
+		{
+			name: "positive: in success report column names in mapping and product header should be compatible regardless of *, spaces, tabs",
+			args: args{
+				source: []map[string]interface{}{
+					{
+						"ProductID*": "1233",
+						"UNSPSC":     "1321442",
+						"PName":      "Test product",
+						"Attribute1": "High availability",
+					},
+				},
+				reportItems: []Report{
+					{
+						ProductId:    "123",
+						Name:         "Test product",
+						Category:     "1321442",
+						CategoryName: "Test Category Name",
+						AttrName:     "Attribute1",
+						AttrValue:    "High availability",
+					},
+				},
+				columnMap: &ColumnMap{
+					Category:  "UNSPSC *",
+					ProductID: "ProductID",
+					Name:      "PName",
+				},
+			},
+			want: []string{
+				"ID",
+				"Category",
+				"Name",
+				"Attribute1",
+			},
+			want1: map[string]int64{
+				"ProductID":  0,
+				"UNSPSC *":   1,
+				"PName":      2,
+				"Attribute1": 3,
+			},
+		},
+		{
+			name: "positive: in success report columns in new header should be ordered: " +
+				"first should be product ID, then-Category, then-all other fields",
+			args: args{
+				source: []map[string]interface{}{
+					{
+						"Attribute1": "AttrValue1",
+						"Category":   "09876",
+						"ID":         "12345",
+					},
+				},
+				reportItems: []Report{
+					{
+						ProductId:    "123",
+						Name:         "Test product",
+						Category:     "1321442",
+						CategoryName: "Test Category Name",
+						AttrName:     "Attribute1",
+						AttrValue:    "High availability",
+					},
+				},
+				columnMap: &ColumnMap{
+					Category:  "Category",
+					ProductID: "ID",
+					Name:      "Name",
+				},
+			},
+			want: []string{
+				"ID",
+				"Category",
+				"Attribute1",
+			},
+			want1: map[string]int64{
+				"ID":         0,
+				"Category":   1,
+				"Attribute1": 2,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := buildSuccessReportHeader(tt.args.source, tt.args.reportItems, tt.args.columnMap)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildSuccessReportHeader() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("buildSuccessReportHeader() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func Test_getSourceKeys(t *testing.T) {
+	type args struct {
+		sourceRow map[string]interface{}
+		columnMap *ColumnMap
+	}
+	tests := []struct {
+		name string
+		args args
+		want *ColumnMap
+	}{
+		{
+			name: "positive: should be selected compatible with mapped column names from source product data",
+			args: args{
+				sourceRow: map[string]interface{}{
+					"UNSPSC":        "1111",
+					"ProductID*":    "22222",
+					"Name ":         "33333",
+					"Category Name": "44444",
+				},
+				columnMap: &ColumnMap{
+					Category:  "Unspsc",
+					ProductID: "Product ID",
+					Name:      "NAME*",
+				},
+			},
+			want: &ColumnMap{
+				Category:  "UNSPSC",
+				ProductID: "ProductID*",
+				Name:      "Name ",
+			},
+		},
+		{
+			name: "positive: should not be selected column names from source products data which are incompatible " +
+				"with mapping column names",
+			args: args{
+				sourceRow: map[string]interface{}{
+					"Category":   "1111",
+					"ProductID*": "22222",
+					"Name":       "33333",
+				},
+				columnMap: &ColumnMap{
+					Category:  "Unspsc",
+					ProductID: "ProductID",
+					Name:      "Name",
+				},
+			},
+			want: &ColumnMap{
+				ProductID: "ProductID*",
+				Name:      "Name",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getSourceKeys(tt.args.sourceRow, tt.args.columnMap); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getSourceKeys() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/productImport/reports/successReportBuilder.go
+++ b/productImport/reports/successReportBuilder.go
@@ -1,0 +1,143 @@
+package reports
+
+import (
+	"fmt"
+	"ts/utils"
+)
+
+const (
+	tsCategoryKey  = "Category"
+	tsProductIdKey = "ID"
+	tsNameKey      = "Name"
+)
+
+func (r *ReportsHandler) buildSuccessData(report []Report, source []map[string]interface{}) [][]string {
+	var res [][]string
+	res = r.buildSuccessMapRaw(source, report)
+	return res
+}
+
+/**
+* transformation iteration
+ */
+func (r *ReportsHandler) buildSuccessMapRaw(source []map[string]interface{}, reportItems []Report) [][]string {
+
+	tsFormattedHeader, headerIndex := buildSuccessReportHeader(source, reportItems, r.ColumnMap)
+	// reset length
+	headerLength := len(tsFormattedHeader)
+
+	// build final report
+	report := make([][]string, 1)
+	report[0] = tsFormattedHeader
+	product := make([]string, 0)
+	productId := ""
+
+	sourceColumnMap := getSourceKeys(source[0], r.ColumnMap)
+	for _, attribute := range reportItems {
+		if productId != attribute.ProductId {
+			productId = attribute.ProductId
+			//if product does not exist in the report yet
+			if len(product) > 0 {
+				report = append(report, product)
+			}
+
+			// first feel data from source file:
+			// - find product for attribute
+			var foundProduct map[string]interface{}
+			for _, sourceItem := range source {
+				if sourceItem[sourceColumnMap.ProductID] == attribute.ProductId {
+					foundProduct = sourceItem
+					break
+				}
+			}
+
+			// - fill attributes
+			product = make([]string, headerLength)
+			for itemAttr, attrValue := range foundProduct {
+				if i, ok := headerIndex[itemAttr]; ok {
+					product[i] = fmt.Sprintf("%v", attrValue)
+				}
+			}
+
+			// fill main info for product:
+			if attribute.Category == "" {
+				product[categoryIndex] = fmt.Sprintf("%v", foundProduct[sourceColumnMap.Category])
+			} else {
+				product[categoryIndex] = attribute.Category
+			}
+
+			product[idIndex] = attribute.ProductId
+
+			// fill fixed attribute value:
+			if i, ok := headerIndex[attribute.AttrName]; ok {
+				product[i] = attribute.AttrValue
+			}
+		} else {
+			if i, ok := headerIndex[attribute.AttrName]; ok {
+				product[i] = attribute.AttrValue
+			}
+		}
+	}
+
+	if len(product) > 0 {
+		report = append(report, product)
+	}
+	return report
+}
+
+func getSourceKeys(sourceRow map[string]interface{}, columnMap *ColumnMap) *ColumnMap {
+	var sourceColumnMap ColumnMap
+	for k, _ := range sourceRow {
+		key := fmt.Sprintf("%v", k)
+		switch utils.TrimAll(key) {
+		case utils.TrimAll(columnMap.Category):
+			sourceColumnMap.Category = key
+		case utils.TrimAll(columnMap.ProductID):
+			sourceColumnMap.ProductID = key
+		case utils.TrimAll(columnMap.Name):
+			sourceColumnMap.Name = key
+		}
+	}
+	return &sourceColumnMap
+}
+
+func buildSuccessReportHeader(source []map[string]interface{}, reportItems []Report, columnMap *ColumnMap) ([]string, map[string]int64) {
+	// headers from the source but ID and Category go first
+	sourceRow := source[0]
+	sourceOrderedHeader := make([]string, 2)
+	sourceOrderedHeader[idIndex] = columnMap.ProductID
+	sourceOrderedHeader[categoryIndex] = columnMap.Category
+	for k := range sourceRow {
+		if utils.TrimAll(k) != utils.TrimAll(columnMap.ProductID) && utils.TrimAll(k) != utils.TrimAll(columnMap.Category) {
+			sourceOrderedHeader = append(sourceOrderedHeader, k)
+		}
+	}
+	// build index of header cols
+	headerLength := len(sourceOrderedHeader)
+	headerIndex := make(map[string]int64, headerLength)
+	for i, v := range sourceOrderedHeader {
+		headerIndex[v] = int64(i)
+	}
+	//form correct header with Mappings
+	headerTs := make([]string, len(sourceOrderedHeader))
+	for i, v := range sourceOrderedHeader {
+		switch utils.TrimAll(v) {
+		case utils.TrimAll(columnMap.Category):
+			headerTs[i] = tsCategoryKey
+		case utils.TrimAll(columnMap.ProductID):
+			headerTs[i] = tsProductIdKey
+		case utils.TrimAll(columnMap.Name):
+			headerTs[i] = tsNameKey
+		default:
+			headerTs[i] = v
+		}
+	}
+	//check all the ontology attribute columns are defined and if not - extend headerIndex and headerTs
+	for _, reportItem := range reportItems {
+		if _, ok := headerIndex[reportItem.AttrName]; !ok {
+			headerTs = append(headerTs, reportItem.AttrName)
+			headerIndex[reportItem.AttrName] = int64(len(headerTs) - 1)
+		}
+	}
+	return headerTs, headerIndex
+}


### PR DESCRIPTION
Columns from mapping with spaces or *-symbols in source data are concidered as valid and similar columns
In report this column names was not proceeded as similar - so report had 2 banch of same columns with empty data in relative cells

Also was separated and refactored logic of header building. And Success Report data builder functions were separated to own file.
Added acceptence test coverage for Transformation logic (Success report building)