### PR TITLE
TSAPPS-243 Add  Offer Item import entry point

### DIFF
--- a/di/di.go
+++ b/di/di.go
@@ -11,6 +11,7 @@ import (
 	"ts/offerImport/importHandler"
 	"ts/offerImport/offerReader"
 	"ts/offerItemImport"
+	"ts/offerItemImport/offerItemMapping"
 	"ts/outwardImport/importToTradeshift"
 	"ts/prepareImport"
 	"ts/productImport"
@@ -43,7 +44,7 @@ var diConfig = []entry{
 
 	{constructor: ontologyValidator.NewValidator},
 	{constructor: reports.NewReportsHandler},
-	{constructor: offerItemImport.NewOfferItemMappingHandler},
+	{constructor: offerItemMapping.NewOfferItemMappingHandler},
 
 	{constructor: rest.NewRestClient},
 	{constructor: tradeshiftAPI.NewTradeshiftAPI},

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"ts/config"
 	"ts/di"
 	"ts/offerImport"
+	"ts/offerItemImport"
 	"ts/prepareImport"
 	"ts/productImport"
 )
@@ -25,9 +26,11 @@ func start(
 	prepareImportHandler *prepareImport.Handler,
 	productImportHandler *productImport.ProductImportHandler,
 	offerImportHandler *offerImport.OfferImportHandler,
+	offerItemImportHandler offerItemImport.OfferItemImportHandlerInterface,
 ) {
 	prepareImportHandler.Run()
 	offerImportHandler.RunCSV()
 	productImportHandler.RunCSV()
+	offerItemImportHandler.Run()
 	return
 }

--- a/offerImport/importHandler/importOffersToTradeshift.go
+++ b/offerImport/importHandler/importOffersToTradeshift.go
@@ -25,7 +25,7 @@ func (i *ImportOfferHandler) ImportOffers(offers []offerReader.RawOffer) {
 			log.Printf("failed to import offer \"%v\". Reason:  %v", offer, err)
 			break
 		}
-
+		log.Printf("IMPORT OFFERS TO TRADESHIFT WAS STARTED")
 		_, err := i.ImportOffer(
 			offer.Offer,
 			offer.Receiver,

--- a/offerItemImport/offerItemInterface.go
+++ b/offerItemImport/offerItemInterface.go
@@ -5,6 +5,3 @@ type OfferItemImportHandlerInterface interface {
 	Run()
 }
 
-type OfferItemMappingHandlerInterface interface {
-	Run() error
-}

--- a/offerItemImport/offerItemMapping/offerItemMappingHandler.go
+++ b/offerItemImport/offerItemMapping/offerItemMappingHandler.go
@@ -1,6 +1,7 @@
-package offerItemImport
+package offerItemMapping
 
 import (
+	"fmt"
 	"path/filepath"
 	"ts/adapters"
 	"ts/file/csvFile"
@@ -23,9 +24,12 @@ func NewOfferItemMappingHandler(deps Deps) OfferItemMappingHandlerInterface {
 	}
 }
 func (oi *OfferItemMappingHandler) Run() error {
-	files := adapters.GetFiles(oi.sourcePath)
+	fileNames := adapters.GetFiles(oi.sourcePath)
+	if len(fileNames) == 0 {
+		return fmt.Errorf("no offer items files found in %v", oi.sourcePath)
+	}
 	{
-		for _, fileName := range files {
+		for _, fileName := range fileNames {
 			err := oi.applyMapping(fileName)
 			if err != nil {
 				return err

--- a/offerItemImport/offerItemMapping/offerItemMappingHandler_test.go
+++ b/offerItemImport/offerItemMapping/offerItemMappingHandler_test.go
@@ -1,4 +1,4 @@
-package offerItemImport
+package offerItemMapping
 
 import (
 	"reflect"

--- a/offerItemImport/offerItemMapping/offerItemMappingInterface.go
+++ b/offerItemImport/offerItemMapping/offerItemMappingInterface.go
@@ -1,17 +1,19 @@
-package offerItemImport
+package offerItemMapping
 
 import (
 	"go.uber.org/dig"
 	"ts/config"
-	"ts/offerItemImport/offerItemMapping"
 	"ts/outwardImport"
 	"ts/productImport/mapping"
 )
 
+type OfferItemMappingHandlerInterface interface {
+	Run() error
+}
+
 type Deps struct {
 	dig.In
 	OutwardImportHandler outwardImport.OutwardImportInterface
-	OfferItemMapping     offerItemMapping.OfferItemMappingHandlerInterface
 	Mapping              mapping.MappingHandlerInterface
 	Config               *config.Config
 }

--- a/productImport/productImportHandler.go
+++ b/productImport/productImportHandler.go
@@ -89,13 +89,13 @@ func (ph *ProductImportHandler) RunCSV() {
 	columnMap := ph.mapHandler.Get()
 
 	// feed
-	err = ph.processProducts(columnMap, rulesConfig)
+	err = ph.runProductValidationImportFlow(columnMap, rulesConfig)
 	if err != nil {
 		log.Println(err)
 	}
 }
 
-func (ph *ProductImportHandler) processProducts(columnMap map[string]string, rulesConfig *models.OntologyConfig) error {
+func (ph *ProductImportHandler) runProductValidationImportFlow(columnMap map[string]string, rulesConfig *models.OntologyConfig) error {
 	// if something in progress
 
 	var processedSource []string


### PR DESCRIPTION
Offer item import should  be processed after offers and products flow.
After converting sheet to csv, csv should be changed according default mapping
Source file should be moved to success_path
From success path file should be taken and imported to Tradeshift.
Report result should be placed to report_path (if it was completed)