### PR TITLE
TSAPPS-253 Remove extra parameter from config

### DIFF
--- a/adapters/filesManager.go
+++ b/adapters/filesManager.go
@@ -12,12 +12,10 @@ import (
 
 //TODO: needs cleanup
 type FileManager struct {
-	SourcePath                 string
-	SecondValidationSourcePath string
-	MappingPath                string
-	OntologyPath               string
-	ReportPath                 string
-
+	SourcePath              string
+	MappingPath             string
+	OntologyPath            string
+	ReportPath              string
 	SentPath                string
 	InProgressPath          string
 	SuccessResultFolderPath string
@@ -27,16 +25,15 @@ type FileManager struct {
 func NewFileManager(deps Deps) *FileManager {
 	conf := deps.Config.ProductCatalog
 	return &FileManager{
-		SourcePath:                 conf.SourcePath,
-		SecondValidationSourcePath: conf.SecondValidationSourcePath,
-		MappingPath:                conf.MappingPath,
-		OntologyPath:               conf.OntologyPath,
-		ReportPath:                 conf.ReportPath,
+		SourcePath:   conf.SourcePath,
+		MappingPath:  conf.MappingPath,
+		OntologyPath: conf.OntologyPath,
+		ReportPath:   conf.ReportPath,
 
 		SentPath:                conf.SentPath,
 		InProgressPath:          conf.InProgressPath,
 		SuccessResultFolderPath: conf.SuccessResultPath,
-		FailResultFolderPath:    conf.FailResultPath,
+		FailResultFolderPath:    conf.ReportPath,
 	}
 }
 

--- a/config/configModels/configModels.go
+++ b/config/configModels/configModels.go
@@ -5,15 +5,13 @@ type ServiceConfig struct {
 }
 
 type ProductCatalogConfig struct {
-	SourcePath                 string
-	ReportPath                 string
-	SecondValidationSourcePath string
-	MappingPath                string
-	OntologyPath               string
-	SentPath                   string
-	InProgressPath             string
-	SuccessResultPath          string
-	FailResultPath             string
+	SourcePath        string
+	ReportPath        string
+	MappingPath       string
+	OntologyPath      string
+	SentPath          string
+	InProgressPath    string
+	SuccessResultPath string
 }
 
 type OfferCatalogConfig struct {

--- a/config/configModels/rawCatalogConfigModel.go
+++ b/config/configModels/rawCatalogConfigModel.go
@@ -2,14 +2,12 @@ package configModels
 
 type RawProductCatalogConfig struct {
 	SourcePath                 string `yaml:"source"`
-	ReportPath                 string `yaml:"report"`
-	SecondValidationSourcePath string `yaml:"source2"`
 	MappingPath                string `yaml:"mapping"`
 	OntologyPath               string `yaml:"ontology"`
 	SentPath                   string `yaml:"sent"`
 	InProgressPath             string `yaml:"in_progress"`
+	ReportPath                 string `yaml:"report"`
 	SuccessResultPath          string `yaml:"success_result"`
-	FailResultPath             string `yaml:"fail_result"`
 }
 
 type RawOfferCatalogConfig struct {
@@ -28,13 +26,11 @@ func (c *RawProductCatalogConfig) ToConfig() *ProductCatalogConfig {
 	return &ProductCatalogConfig{
 		SourcePath:                 c.SourcePath,
 		ReportPath:                 c.ReportPath,
-		SecondValidationSourcePath: c.SecondValidationSourcePath,
 		MappingPath:                c.MappingPath,
 		OntologyPath:               c.OntologyPath,
 		SentPath:                   c.SentPath,
 		InProgressPath:             c.InProgressPath,
 		SuccessResultPath:          c.SuccessResultPath,
-		FailResultPath:             c.FailResultPath,
 	}
 }
 

--- a/productImport/productImportHandler.go
+++ b/productImport/productImportHandler.go
@@ -118,7 +118,7 @@ func (ph *ProductImportHandler) runProductValidationImportFlow(columnMap map[str
 					"Please check the failure report in '%v', "+
 					"fill it with the data and appload to the '%v' folder.",
 					ph.config.ProductCatalog.InProgressPath+"/"+processingFile,
-					ph.config.ProductCatalog.FailResultPath,
+					ph.config.ProductCatalog.ReportPath,
 					ph.config.ProductCatalog.SourcePath)
 			}
 		}
@@ -212,7 +212,8 @@ func (ph *ProductImportHandler) processFeed(
 		}
 	}
 
-	cleanUpAttributeReports(sourceFeedPath, ph.config.ProductCatalog.FailResultPath)
+	cleanUpAttributeReports(sourceFeedPath, ph.config.ProductCatalog.ReportPath)
+
 	validationReportPath = ph.reports.WriteReport(sourceFeedPath, hasErrors, feed, parsedData)
 	if !hasErrors {
 		log.Println("IMPORT FEED TO TRADESHIFT WAS STARTED")

--- a/productImport/reports/reportsHandler.go
+++ b/productImport/reports/reportsHandler.go
@@ -37,7 +37,7 @@ func NewReportsHandler(deps Deps) *ReportsHandler {
 		ColumnMapConfig:   m,
 		Header:            initFailedAttributesReportHeader(m),
 		SuccessResultPath: conf.SuccessResultPath,
-		FailResultPath:    conf.FailResultPath,
+		FailResultPath:    conf.ReportPath,
 	}
 }
 

--- a/service.default.yaml
+++ b/service.default.yaml
@@ -1,10 +1,9 @@
 product:
   source: ./data/source/products/
-  report: ./data/result/report/
   sent: ./data/source/processed/products/
   in_progress: ./data/source/inprogress/
+  report: ./data/result/report/
   success_result: ./data/result/sent/
-  fail_result: ./data/result/report/
   mapping: ./data/mapping/mapping.yaml
   ontology: ./data/ontology/rules.csv
 


### PR DESCRIPTION
By request of PM: config has extra "fail_path" parameter in config. Report_path can be used instead of it
Also removed wrong and unused config parameter 'source2'