### PR TITLE
TSAPPS-227_add-file-names

### DIFF
--- a/prepareImport/prepareImportHandler.go
+++ b/prepareImport/prepareImportHandler.go
@@ -44,12 +44,12 @@ func NewPrepareImportHandler(deps Deps) *Handler {
 			commonConf.Sheet.Offers,
 			0,
 			conf.OfferCatalog.SourcePath,
-			""),
+			"_offers"),
 		offerItemConverter: NewXLSXSheetToCSVConverter(
 			commonConf.Sheet.OfferItems.Name,
 			commonConf.Sheet.OfferItems.HeaderRowsToSkip,
 			conf.OfferItemCatalog.SourcePath,
-			""),
+			"_offer_items"),
 	}
 }
 


### PR DESCRIPTION
User should be able to differ which file from which sheet of source xlsx was generated. So it is required to add suffixes to file names (except failures-it will be fixed in TSAPPS-221)