### PR TITLE
TSAPPS-293 Fix bug for UOM column name

### DIFF
--- a/productImport/reports/reportHeader_test.go
+++ b/productImport/reports/reportHeader_test.go
@@ -334,3 +334,29 @@ func TestHeaderBuilder_buildSuccessReportHeader(t *testing.T) {
 		})
 	}
 }
+
+func Test_buildUOMColumnName(t *testing.T) {
+	type args struct {
+		attrName string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Positive: first, last and duplicated spaces should be removed from attribute-name when it is used as UoM column_name",
+			args: args{
+				attrName: "   Mobile  phones ",
+			},
+			want: "Mobile phones_UOM",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildUOMColumnName(tt.args.attrName); got != tt.want {
+				t.Errorf("buildUOMColumnName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/productImport/reports/successReportHeader.go
+++ b/productImport/reports/successReportHeader.go
@@ -2,6 +2,7 @@ package reports
 
 import (
 	"fmt"
+	"strings"
 	"ts/productImport/mapping"
 	"ts/utils"
 )
@@ -76,6 +77,9 @@ func (h *HeaderBuilder) buildSortedHeader() []string {
 }
 
 func buildUOMColumnName(attrName string) string {
+	attrName = strings.Replace(attrName, "  ", " ", -1)
+	attrName = strings.TrimLeft(attrName, " ")
+	attrName = strings.TrimRight(attrName, " ")
 	return fmt.Sprintf("%v_UOM", attrName)
 }
 


### PR DESCRIPTION
Fixed problem of "holes" in column name "Attribute _UOM" when attribute name has extra spaces at the begin and end