### PR TITLE
TSAPPS-301 replace files in case of system-validation errors

### DIFF
--- a/offerImport/offerImportHandler.go
+++ b/offerImport/offerImportHandler.go
@@ -50,7 +50,8 @@ func (o *OfferImportHandler) RunCSV() {
 func (o *OfferImportHandler) runOfferImportFlow(fileName string) {
 	offers, err := o.uploadOffers(fileName)
 	if err != nil {
-		log.Printf("An error occurred while uploading the offer: %v. Skip step", err)
+		_, _ = adapters.MoveToPath(filepath.Join(o.sourcePath, fileName), o.sentPath)
+		log.Printf("An error occurred while uploading the offer: %v. Skip step, invalid file was moved to %v", err, o.sentPath)
 		return
 	}
 

--- a/productImport/ontologyValidator/attributesValidator.go
+++ b/productImport/ontologyValidator/attributesValidator.go
@@ -11,7 +11,7 @@ import (
 	"ts/utils"
 )
 
-func (v *Validator) validateAttributes(
+func (v *Validator) validateAttributesAgainstRules(
 	rulesData *models.OntologyConfig,
 	productData *product.Products,
 	attributeData []*attribute.Attribute) ([]reports.Report, bool) {

--- a/productImport/ontologyValidator/productsValidator.go
+++ b/productImport/ontologyValidator/productsValidator.go
@@ -4,28 +4,26 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"ts/productImport/attribute"
 	"ts/productImport/ontologyRead/models"
 	"ts/productImport/ontologyRead/rawOntology"
 	"ts/productImport/reports"
 	"ts/utils"
 )
 
-func (v *Validator) validateSource(data struct {
-	Mapping       map[string]string
-	Rules         *models.OntologyConfig
-	SourceData    []map[string]interface{}
-	AttributeData []*attribute.Attribute
-}) ([]reports.Report, bool) {
+func (v *Validator) validateProductsAgainstRules(
+	mapping       map[string]string,
+	rules         *models.OntologyConfig,
+	sourceData    []map[string]interface{},
+) ([]reports.Report, bool) {
 	feed := make([]reports.Report, 0)
 	var columnMapIndex map[string]string
-	if data.Mapping != nil && len(data.Mapping) > 0 {
-		columnMapIndex = utils.RevertMapKeyValue(data.Mapping)
+	if mapping != nil && len(mapping) > 0 {
+		columnMapIndex = utils.RevertMapKeyValue(mapping)
 	}
-	currentSourceMap := v.productHandler.GetCurrentHeader(data.SourceData[0])
+	currentSourceMap := v.productHandler.GetCurrentHeader(sourceData[0])
 
 	isError := false
-	for _, product := range data.SourceData {
+	for _, product := range sourceData {
 		var id string
 		var category string
 		if val, ok := product[currentSourceMap.Category]; ok {
@@ -57,7 +55,7 @@ func (v *Validator) validateSource(data struct {
 				Errors:    []string{"The product category is not specified. The product can not be validated."},
 			})
 		} else {
-			if ruleCategory, ok := data.Rules.Categories[category]; ok {
+			if ruleCategory, ok := rules.Categories[category]; ok {
 				for _, attr := range ruleCategory.Attributes {
 					val := ""
 					message := make([]string, 0)

--- a/productImport/ontologyValidator/validator.go
+++ b/productImport/ontologyValidator/validator.go
@@ -30,20 +30,33 @@ func NewValidator(deps Deps) ValidatorInterface {
 	}
 }
 
-func (v *Validator) Validate(data struct {
-	Mapping       map[string]string
-	Rules         *models.OntologyConfig
-	SourceData    []map[string]interface{}
-	AttributeData []*attribute.Attribute
-}) ([]reports.Report, bool) {
+func (v *Validator) InitialValidation(
+	mapping map[string]string,
+	rules *models.OntologyConfig,
+	sourceData []map[string]interface{}) ([]reports.Report, bool) {
+	report, isErr := v.validateProductsAgainstRules(mapping,
+		rules,
+		sourceData,
+	)
+	return report, isErr
+}
 
-	parsedProducts := v.productHandler.InitParsedSourceData(data.SourceData)
+func (v *Validator) SecondaryValidation(
+	mapping map[string]string,
+	rules *models.OntologyConfig,
+	sourceData []map[string]interface{},
+	attributeData []*attribute.Attribute,
+) ([]reports.Report, bool) {
 
-	if data.AttributeData != nil && len(data.AttributeData) > 0 {
-		report, isErr := v.validateAttributes(data.Rules, parsedProducts, data.AttributeData)
+	parsedProducts := v.productHandler.InitParsedSourceData(sourceData)
+	if attributeData != nil && len(attributeData) > 0 {
+		report, isErr := v.validateAttributesAgainstRules(rules, parsedProducts, attributeData)
 		return report, isErr
 	}
 
-	report, isErr := v.validateSource(data)
+	report, isErr := v.validateProductsAgainstRules(mapping,
+		rules,
+		sourceData,
+	)
 	return report, isErr
 }

--- a/productImport/ontologyValidator/validatorInterface.go
+++ b/productImport/ontologyValidator/validatorInterface.go
@@ -12,14 +12,16 @@ import (
 type Deps struct {
 	dig.In
 	ProductHandler product.ProductHandlerInterface
-	Mapper mapping.MappingHandlerInterface
+	Mapper         mapping.MappingHandlerInterface
 }
 
 type ValidatorInterface interface {
-	Validate(data struct {
-		Mapping       map[string]string
-		Rules         *models.OntologyConfig
-		SourceData    []map[string]interface{}
-		AttributeData []*attribute.Attribute
-	}) ([]reports.Report, bool)
+	InitialValidation(mapping map[string]string,
+		rules *models.OntologyConfig,
+		sourceData []map[string]interface{}) ([]reports.Report, bool)
+	SecondaryValidation(
+		mapping map[string]string,
+		rules *models.OntologyConfig,
+		sourceData []map[string]interface{},
+		attributeData []*attribute.Attribute) ([]reports.Report, bool)
 }


### PR DESCRIPTION
When source product file, offer file or attributes file has bad format (but not wrong values from business point of view - in comparance with ontology), tool returns error and stops,
 invalid file still stay in inProgress folder
In case of rerun with valid xlsx data this file is still used as previous result and breaks tool again
In this case invalid csv file should be moved away from inprogress folder.

Also splitted processing and validation for validation 1 (when we have only products file) and validation2 flow (when we have iteration with changes - attributes and products file)