### PR TITLE
TSAPPS-302 Make Recipients config param unrequired

### DIFF
--- a/config/configModels/rawTradeshiftConfigModel.go
+++ b/config/configModels/rawTradeshiftConfigModel.go
@@ -9,7 +9,7 @@ type RawTradeshiftAPIConfig struct {
 	TenantId       string         `yaml:"tenant_id" validate:"required"`
 	Currency       string         `yaml:"currency" validate:"required"`
 	FileLocale     string         `yaml:"file_locale" validate:"required"`
-	Recipients     []RawRecipient `yaml:"recipients" validate:"required"`
+	Recipients     []RawRecipient `yaml:"recipients"`
 }
 
 type RawRecipient struct {

--- a/offerImport/importHandler/importOffersToTradeshift_test.go
+++ b/offerImport/importHandler/importOffersToTradeshift_test.go
@@ -1,0 +1,36 @@
+package importHandler
+
+import "testing"
+
+func Test_isId(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "id consists of 5 hex-formatted parts connected with '-'",
+			args: args{
+				input: "2addd7f5-5633-4c74-b3d7-760d04f1e4cc",
+			},
+			want: true,
+		},
+		{
+			name: "nonHexFormated string is not considered as id",
+			args: args{
+				input: "2add7f5-5633-4c74-bRd7-760d04f1e4cc",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isId(tt.args.input); got != tt.want {
+				t.Errorf("isId() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Recipients mapping in config is not required:
- offer import can be skipped
- we expect Recipient ID in Recipient as well as Recipient Name