### PR TITLE
TSAPPS-303 update config params

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This data will be filled in properly when you will build the tool. So there aren
 
 If you use XLSX file then the following properties has to be filled in to define a name of each sheet from your file for each type of data. It is needed in case if you use own names for these sheets. You also can define the count of header lines that has to be skipped. The configuration that you can find below means that the header line will start from third line. The first two lines will be skipped.
 
-        common:
+        xlsx_settings:
           source: ./data/source/
           sent: ./data/source/processed/
           sheet:
@@ -78,7 +78,7 @@ If you use XLSX file then the following properties has to be filled in to define
             offers:
               name: "Offers"
               header_rows_to_skip: 2
-            failures:
+            attributes:
               name: "Attributes"
               header_rows_to_skip: 2
             offer_items:

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	ProductCatalog   configModels.ProductCatalogConfig
 	OfferCatalog     configModels.OfferCatalogConfig
 	OfferItemCatalog configModels.OfferItemCatalogConfig
-	CommonConfig     configModels.CommonConfig
+	XLSXConfig       *configModels.XLSXConfig
 	TradeshiftAPI    configModels.TradeshiftAPIConfig
 }
 
@@ -54,13 +54,13 @@ func configFromRaw(rawService *configModels.RawServiceConfig) *Config {
 	t := rawService.TradeshiftAPIConfig
 	o := rawService.OfferCatalogConfig
 	oi := rawService.OfferItemCatalogConfig
-	c := rawService.CommonConfig
+	c := rawService.XLSXConfig
 	return &Config{
 		Service:          *rawService.ToConfig(),
 		ProductCatalog:   *p.ToConfig(),
 		OfferCatalog:     *o.ToConfig(),
 		OfferItemCatalog: *oi.ToConfig(),
-		CommonConfig:     *c.ToConfig(),
+		XLSXConfig:       c.ToConfig(),
 		TradeshiftAPI:    *t.ToConfig(),
 	}
 }

--- a/config/configModels/configModels.go
+++ b/config/configModels/configModels.go
@@ -26,7 +26,7 @@ type OfferItemCatalogConfig struct {
 	SentPath          string
 }
 
-type CommonConfig struct {
+type XLSXConfig struct {
 	SourcePath string
 	SentPath   string
 	Sheets     *SheetsConfig
@@ -35,7 +35,7 @@ type CommonConfig struct {
 type SheetsConfig struct {
 	Products   *SheetParamsConfig
 	Offers     *SheetParamsConfig
-	Failures   *SheetParamsConfig
+	Attributes *SheetParamsConfig
 	OfferItems *SheetParamsConfig
 }
 

--- a/config/configModels/rawServiceConfigModel.go
+++ b/config/configModels/rawServiceConfigModel.go
@@ -5,8 +5,8 @@ type RawServiceConfig struct {
 	ProductCatalogConfig   RawProductCatalogConfig   `yaml:"product" validate:"required"`
 	OfferCatalogConfig     RawOfferCatalogConfig     `yaml:"offer" validate:"required"`
 	OfferItemCatalogConfig RawOfferItemCatalogConfig `yaml:"offer_item" validate:"required"`
-	CommonConfig           RawCommonCatalogConfig    `yaml:"common" validate:"required"`
 	TradeshiftAPIConfig    RawTradeshiftAPIConfig    `yaml:"tradeshift_api" validate:"required"`
+	XLSXConfig             RawXLSXConfig             `yaml:"xlsx_settings"`
 }
 
 func (c *RawServiceConfig) ToConfig() *ServiceConfig {

--- a/config/configModels/rawXLSXConfigModel.go
+++ b/config/configModels/rawXLSXConfigModel.go
@@ -1,6 +1,6 @@
 package configModels
 
-type RawCommonCatalogConfig struct {
+type RawXLSXConfig struct {
 	SourcePath string         `yaml:"source"`
 	SentPath   string         `yaml:"sent"`
 	Sheet      RawSheetConfig `yaml:"sheet"`
@@ -10,7 +10,7 @@ type RawSheetConfig struct {
 	Products   RawSheetParamsConfig `yaml:"products"`
 	Offers     RawSheetParamsConfig `yaml:"offers"`
 	OfferItems RawSheetParamsConfig `yaml:"offer_items"`
-	Failures   RawSheetParamsConfig `yaml:"failures"`
+	Attributes RawSheetParamsConfig `yaml:"attributes"`
 }
 
 type RawSheetParamsConfig struct {
@@ -18,14 +18,17 @@ type RawSheetParamsConfig struct {
 	HeaderRowsToSkip int    `yaml:"header_rows_to_skip"`
 }
 
-func (c *RawCommonCatalogConfig) ToConfig() *CommonConfig {
-	return &CommonConfig{
+func (c *RawXLSXConfig) ToConfig() *XLSXConfig {
+	if *c == (RawXLSXConfig{}) {
+		return nil
+	}
+	return &XLSXConfig{
 		SourcePath: c.SourcePath,
 		SentPath:   c.SentPath,
 		Sheets: &SheetsConfig{
 			Products:   c.Sheet.Products.ToConfig(),
 			Offers:     c.Sheet.Offers.ToConfig(),
-			Failures:   c.Sheet.Failures.ToConfig(),
+			Attributes: c.Sheet.Attributes.ToConfig(),
 			OfferItems: c.Sheet.OfferItems.ToConfig(),
 		},
 	}

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ offer_item:
   report: ${DIR}/data/result/report/
   sent: ${DIR}/data/source/processed/offerItems/
 
-common:
+xlsx_settings:
   source: ${DIR}/data/source/
   sent: ${DIR}/data/source/processed/
   sheet:
@@ -31,7 +31,7 @@ common:
     offers:
       name: "Offers"
       header_rows_to_skip: 2
-    failures:
+    attributes:
       name: "Attributes"
       header_rows_to_skip: 2
     offer_items:

--- a/main.go
+++ b/main.go
@@ -28,7 +28,9 @@ func start(
 	offerImportHandler *offerImport.OfferImportHandler,
 	offerItemImportHandler offerItemImport.OfferItemImportHandlerInterface,
 ) {
-	prepareImportHandler.Run()
+	if prepareImportHandler != nil {
+		prepareImportHandler.Run()
+	}
 	offerImportHandler.RunCSV()
 	productImportHandler.RunCSV()
 	offerItemImportHandler.Run()

--- a/service.default.yaml
+++ b/service.default.yaml
@@ -17,7 +17,7 @@ offer_item:
   report: ./data/result/report/
   sent: ./data/source/processed/offerItems/
 
-common:
+xlsx_settings:
   source: ./data/source/
   sent: ./data/source/processed/
   sheet:
@@ -27,7 +27,7 @@ common:
     offers:
       name: "Offers"
       header_rows_to_skip: 2
-    failures:
+    attributes:
       name: "Attributes"
       header_rows_to_skip: 2
     offer_items:


### PR DESCRIPTION
"failures" config parameter should be renamed to attributes, we do not use "failures" any more
"common" - is not obvious config parameter name, it is contains params for excel-file flow and should be named according this purpose.
It should not be required, because tool can be run without xlsx file.