### PR TITLE
TSAPPS-305 Process empty header in xlsx file's sheet

### DIFF
--- a/file/converter.go
+++ b/file/converter.go
@@ -16,6 +16,11 @@ func XLSXToCSV(sourceFilePath string, sheet string, headerRowsToSkip int, destin
 	if len(data) == 0 {
 		return false, nil
 	}
+	header := data[headerRowsToSkip]
+	if utils.IsEmptyRow(header) {
+		return false, fmt.Errorf("header is empty, sheet %v can not be processed", sheet)
+	}
+
 	clearedData := clearEmptyData(data, headerRowsToSkip)
 	if len(clearedData) == 0 {
 		return false, fmt.Errorf("there is no valid data found on sheet %v", sheet)
@@ -31,7 +36,8 @@ func XLSXToCSV(sourceFilePath string, sheet string, headerRowsToSkip int, destin
 
 func clearEmptyData(data [][]string, headerRowsToSkip int) [][]string {
 	var res [][]string
-	columnIndexes := getValidColumnIndexes(data[headerRowsToSkip])
+	header := data[headerRowsToSkip]
+	columnIndexes := getValidColumnIndexes(header)
 
 	if len(columnIndexes) == 0 {
 		return res

--- a/productImport/productImportHandler.go
+++ b/productImport/productImportHandler.go
@@ -114,16 +114,16 @@ func (ph *ProductImportHandler) runProductValidationImportFlow(columnMap map[str
 					false,
 				)
 			} else {
-				log.Printf("You have the failed feed in progress '%v'. "+
-					"Please check the failure report in '%v', "+
-					"fill it with the data and appload to the '%v' folder.",
+				log.Printf("You have a feed in progress ('%v') that is waiting for attributes corrections. " +
+					"Please check the report in '%v' or move this feed to the '%v' folder " +
+					"to get a report once again.",
 					ph.config.ProductCatalog.InProgressPath+"/"+processingFile,
 					ph.config.ProductCatalog.ReportPath,
 					ph.config.ProductCatalog.SourcePath)
 			}
 		}
 	} else if len(sources) == 0 {
-		return fmt.Errorf("PRODUCT SOURCE FILES WAS NOT FOUND")
+		return fmt.Errorf("Products source folder is empty. Nothing to import.")
 	}
 
 	for _, source := range sources {


### PR DESCRIPTION
Found problem:
in xlsx file at sheet Attributes were empty header. File was not generated, but import flow was started and proceeded unclear error message

Fixed in 2 points:
1. In case of empty header in XLSX file we should mark sheet as invalid and  warn user about it, file should not be generated
2. Fixed error message for Product+Attributes flow in case if Attributes file absence and in case of Product file absence
(if they were not generated by reason from p.1 for example)