### PR TITLE
TSAPPS-309 Add mapping support to offerItems flow

### DIFF
--- a/data/mapping/mapping.yaml
+++ b/data/mapping/mapping.yaml
@@ -1,4 +1,4 @@
-# Column mapping is applied to the source file to identify ID and Category Columns
+# Column mapping is applied to the source file to identify TradeShift Column names for products and prices
 # As well applied to the final product of the script (final product feed)
 # The key represents the name of TS column
 # The value reflects the source file column name:

--- a/offerItemImport/offerItemMapping/offerItemMappingHandler.go
+++ b/offerItemImport/offerItemMapping/offerItemMappingHandler.go
@@ -6,7 +6,6 @@ import (
 	"ts/adapters"
 	"ts/file/csvFile"
 	"ts/productImport/mapping"
-	"ts/utils"
 )
 
 type OfferItemMappingHandler struct {
@@ -50,14 +49,15 @@ func (oi *OfferItemMappingHandler) applyMapping(fileName string) error {
 	return nil
 }
 
-func (oi *OfferItemMappingHandler) buildHeader(row []string) []string {
-	res := make([]string, len(row))
-	for i, value := range row {
-		if utils.TrimAll(value) == utils.TrimAll(oi.columnMap.ProductID) {
-			res[i] = "ID"
-			continue
+func (oi *OfferItemMappingHandler) buildHeader(headerRow []string) []string {
+	res := make([]string, len(headerRow))
+	for i, value := range headerRow {
+		mapped := oi.columnMap.GetDefaultValueByMapped(value)
+		if mapped == nil {
+			res[i] = value
+		} else {
+			res[i] = mapped.DefaultKey
 		}
-		res[i] = value
 	}
 	return res
 }

--- a/offerItemImport/offerItemMapping/offerItemMappingHandler_test.go
+++ b/offerItemImport/offerItemMapping/offerItemMappingHandler_test.go
@@ -6,14 +6,14 @@ import (
 	"ts/productImport/mapping"
 )
 
-func TestOfferItemReader_buildHeader(t *testing.T) {
+func TestOfferItemMappingHandler_buildHeader(t *testing.T) {
 	type fields struct {
 		columnMap         *mapping.ColumnMapConfig
 		sourcePath        string
 		successReportPath string
 	}
 	type args struct {
-		row []string
+		headerRow []string
 	}
 	tests := []struct {
 		name   string
@@ -22,25 +22,63 @@ func TestOfferItemReader_buildHeader(t *testing.T) {
 		want   []string
 	}{
 		{
-			name: "positive",
+			name: "positive: mapped columnn names should be converted to default values.",
 			fields: fields{
 				columnMap: &mapping.ColumnMapConfig{
-					ProductID: "Product ID",
+					ProductID: "SKU",
+					Category:  "UNSPSC",
+					OtherColumns: []*mapping.ColumnItem{
+						{
+							DefaultKey: "DefaultKey1",
+							MappedKey:  "MappedKey1",
+						},
+						{
+							DefaultKey: "DefaultKey2",
+							MappedKey:  "MappedKey2",
+						},
+					},
 				},
 			},
 			args: args{
-				row: []string{
-					"Name",
-					"Offer",
-					"productID *",
-					"Price",
+				headerRow: []string{
+					"Sku",
+					"UNSPSC",
+					"DefaultKey2",
 				},
 			},
 			want: []string{
-				"Name",
-				"Offer",
 				"ID",
-				"Price",
+				"Category",
+				"DefaultKey2",
+			},
+		},
+		{
+			name: "positive: if column name is not mapped, should be taken original column name",
+			fields: fields{
+				columnMap: &mapping.ColumnMapConfig{
+					ProductID: "SKU",
+					Category:  "UNSPSC",
+					OtherColumns: []*mapping.ColumnItem{
+						{
+							DefaultKey: "DefaultKey1",
+							MappedKey:  "MappedKey1",
+						},
+					},
+				},
+			},
+			args: args{
+				headerRow: []string{
+					"Sku",
+					"UNSPSC",
+					"DefaultKey1",
+					"Not Mapped Key",
+				},
+			},
+			want: []string{
+				"ID",
+				"Category",
+				"DefaultKey1",
+				"Not Mapped Key",
 			},
 		},
 	}
@@ -51,8 +89,8 @@ func TestOfferItemReader_buildHeader(t *testing.T) {
 				sourcePath:        tt.fields.sourcePath,
 				successReportPath: tt.fields.successReportPath,
 			}
-			if got := oi.buildHeader(tt.args.row); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("buildHeader() = %v, want %v", got, tt.want)
+			if got := oi.buildHeader(tt.args.headerRow); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildMappedHeader() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Some clients would like to import offer items separately and in on file (one tab) with products.
So we need to have a mapping applied for all these columns as well.