### PR TITLE
TSAPPS-310 Add UoM mapping

### DIFF
--- a/config/configModels/configModels.go
+++ b/config/configModels/configModels.go
@@ -9,6 +9,7 @@ type ProductCatalogConfig struct {
 	SourcePath        string
 	ReportPath        string
 	MappingPath       string
+	UoMMappingPath    string
 	OntologyPath      string
 	SentPath          string
 	InProgressPath    string

--- a/config/configModels/rawCatalogConfigModel.go
+++ b/config/configModels/rawCatalogConfigModel.go
@@ -1,13 +1,14 @@
 package configModels
 
 type RawProductCatalogConfig struct {
-	SourcePath                 string `yaml:"source"`
-	MappingPath                string `yaml:"mapping"`
-	OntologyPath               string `yaml:"ontology"`
-	SentPath                   string `yaml:"sent"`
-	InProgressPath             string `yaml:"in_progress"`
-	ReportPath                 string `yaml:"report"`
-	SuccessResultPath          string `yaml:"success_result"`
+	SourcePath        string `yaml:"source"`
+	MappingPath       string `yaml:"mapping"`
+	UoMMappingPath    string `yaml:"uom_mapping"`
+	OntologyPath      string `yaml:"ontology"`
+	SentPath          string `yaml:"sent"`
+	InProgressPath    string `yaml:"in_progress"`
+	ReportPath        string `yaml:"report"`
+	SuccessResultPath string `yaml:"success_result"`
 }
 
 type RawOfferCatalogConfig struct {
@@ -24,13 +25,14 @@ type RawOfferItemCatalogConfig struct {
 
 func (c *RawProductCatalogConfig) ToConfig() *ProductCatalogConfig {
 	return &ProductCatalogConfig{
-		SourcePath:                 c.SourcePath,
-		ReportPath:                 c.ReportPath,
-		MappingPath:                c.MappingPath,
-		OntologyPath:               c.OntologyPath,
-		SentPath:                   c.SentPath,
-		InProgressPath:             c.InProgressPath,
-		SuccessResultPath:          c.SuccessResultPath,
+		SourcePath:        c.SourcePath,
+		ReportPath:        c.ReportPath,
+		MappingPath:       c.MappingPath,
+		UoMMappingPath:    c.UoMMappingPath,
+		OntologyPath:      c.OntologyPath,
+		SentPath:          c.SentPath,
+		InProgressPath:    c.InProgressPath,
+		SuccessResultPath: c.SuccessResultPath,
 	}
 }
 

--- a/data/mapping/uom_mapping.yaml
+++ b/data/mapping/uom_mapping.yaml
@@ -1,0 +1,1 @@
+uom-mappings:

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ product:
   in_progress: ${DIR}/data/source/inprogress/
   success_result: ${DIR}/data/result/sent/
   mapping: ${DIR}/data/mapping/mapping.yaml
+  uom_mapping: ./data/mapping/uom_mapping.yaml
   ontology: ${DIR}/data/ontology/rules.csv
 
 offer:

--- a/productImport/mapping/columnMappingModel.go
+++ b/productImport/mapping/columnMappingModel.go
@@ -12,7 +12,7 @@ type ColumnMapConfig struct {
 	Category     string
 	ProductID    string
 	Name         string
-	OtherColumns []*ColumnItem //todo name
+	OtherColumns []*ColumnItem
 }
 
 type ColumnItem struct {
@@ -42,7 +42,6 @@ func (m *mapping) NewColumnMap(rawMap map[string]string) *ColumnMapConfig {
 	}
 
 	parsedMap.OtherColumns = parseNotRequiredColumns(rawMap)
-
 	return &parsedMap
 }
 

--- a/productImport/mapping/handlerInterface.go
+++ b/productImport/mapping/handlerInterface.go
@@ -7,9 +7,9 @@ import (
 )
 
 type MappingHandlerInterface interface {
-	init(mappingConfigPath string) map[string]string
 	Get() map[string]string
 	GetColumnMapConfig() *ColumnMapConfig
+	GetUoMMapConfig() *UoMMapConfig
 }
 
 type Deps struct {

--- a/productImport/mapping/mapping.go
+++ b/productImport/mapping/mapping.go
@@ -9,32 +9,39 @@ import (
 )
 
 type mapping struct {
-	logger    logger.LoggerInterface
-	rawMap    map[string]string
-	parsedMap *ColumnMapConfig
+	logger            logger.LoggerInterface
+	uomMappingPath    string
+	columnMappingPath string
+	rawMap            map[string]string
+	parsedMap         *ColumnMapConfig
+	uomMap            *UoMMapConfig
 }
 
 func NewMappingHandler(deps Deps) MappingHandlerInterface {
+	conf := deps.Config.ProductCatalog
 	rawMap := mapping{
-		logger: deps.Logger,
+		logger:            deps.Logger,
+		columnMappingPath: conf.MappingPath,
+		uomMappingPath:    conf.UoMMappingPath,
 	}
-	rawMap.init(deps.Config.ProductCatalog.MappingPath)
+	rawMap.initProductsMapping()
+	rawMap.initUoMapping()
 	rawMap.parsedMap = rawMap.NewColumnMap(rawMap.rawMap)
 	return &rawMap
 }
 
-func (m *mapping) init(path string) map[string]string {
+func (m *mapping) initProductsMapping() map[string]string {
 	var rawColumnMap map[string]string
-	if path != "" {
-		if _, err := os.Stat(path); !os.IsNotExist(err) {
-			m.upload(path)
+	if m.columnMappingPath != "" {
+		if _, err := os.Stat(m.columnMappingPath); !os.IsNotExist(err) {
+			m.readColumnMapping(m.columnMappingPath)
 			rawColumnMap = m.Get()
 		}
 	}
 	return rawColumnMap
 }
 
-func (m *mapping) upload(mappingConfigPath string) {
+func (m *mapping) readColumnMapping(mappingConfigPath string) {
 	data, err := ioutil.ReadFile(mappingConfigPath)
 	if err != nil {
 		m.logger.Fatal(fmt.Sprintf("unable to load mapping file from %s", mappingConfigPath), err)
@@ -46,10 +53,34 @@ func (m *mapping) upload(mappingConfigPath string) {
 	m.rawMap = rawMapping.ToConfig()
 }
 
+func (m *mapping) initUoMapping() {
+	if m.uomMappingPath != "" {
+		if _, err := os.Stat(m.uomMappingPath); !os.IsNotExist(err) {
+			m.uomMap = NewUoMMapConfig(m.readUoMMapping(m.uomMappingPath))
+		}
+	}
+}
+
+func (m *mapping) readUoMMapping(uomPath string) []*UoMItem {
+	data, err := ioutil.ReadFile(uomPath)
+	if err != nil {
+		m.logger.Fatal(fmt.Sprintf("unable to load mapping file from %s", uomPath), err)
+	}
+	rawUoMMapping := &RawUomMapping{}
+	if err := yaml.Unmarshal(data, rawUoMMapping); err != nil {
+		m.logger.Fatal(fmt.Sprintf("unable to unmarshal mapping file %s", uomPath), err)
+	}
+	return rawUoMMapping.ToConfig()
+}
+
 func (m *mapping) Get() map[string]string {
 	return m.rawMap
 }
 
 func (m *mapping) GetColumnMapConfig() *ColumnMapConfig {
 	return m.parsedMap
+}
+
+func (m *mapping) GetUoMMapConfig() *UoMMapConfig {
+	return m.uomMap
 }

--- a/productImport/mapping/rawMapping.go
+++ b/productImport/mapping/rawMapping.go
@@ -4,6 +4,22 @@ type RawMapping struct {
 	Map map[string]string `yaml:"column-mappings" validate:"required"`
 }
 
-func (c *RawMapping) ToConfig() map[string]string {
-	return c.Map
+func (rc *RawMapping) ToConfig() map[string]string {
+	return rc.Map
+}
+
+type RawUomMapping struct {
+	Map map[string]string `yaml:"uom-mappings"`
+}
+
+func (ru *RawUomMapping) ToConfig() []*UoMItem {
+	res := make([]*UoMItem, 0)
+	for key, value := range ru.Map {
+		res = append(res, &UoMItem{
+			DefaultKey: key,
+			MappedKey:  value,
+		})
+
+	}
+	return res
 }

--- a/productImport/mapping/uomMappingModel.go
+++ b/productImport/mapping/uomMappingModel.go
@@ -1,0 +1,40 @@
+package mapping
+
+import (
+	"ts/utils"
+)
+
+type UoMItem struct {
+	DefaultKey string
+	MappedKey  string
+}
+
+type UoMMapConfig struct {
+	items map[string]*UoMItem
+}
+
+func NewUoMMapConfig(items []*UoMItem) *UoMMapConfig {
+	res := make(map[string]*UoMItem)
+	for _, item := range items {
+		res[utils.TrimAll(item.MappedKey)] = item
+	}
+	return &UoMMapConfig{
+		items: res,
+	}
+}
+
+func (u *UoMMapConfig) GetDefaultUoMValueByMapped(value string) string {
+	if res, ok := u.items[utils.TrimAll(value)]; ok {
+		return res.DefaultKey
+	}
+	return ""
+}
+
+func (u *UoMMapConfig) GetActualUoMValueByDefault(defaultValue string) string {
+	for _, u := range u.items {
+		if utils.TrimAll(defaultValue) == utils.TrimAll(u.DefaultKey) {
+			return u.MappedKey
+		}
+	}
+	return ""
+}

--- a/productImport/mapping/uomMappingModel_test.go
+++ b/productImport/mapping/uomMappingModel_test.go
@@ -1,0 +1,116 @@
+package mapping
+
+import "testing"
+
+func TestUoMMapConfig_GetActualUoMValueByDefault(t *testing.T) {
+	type fields struct {
+		items map[string]*UoMItem
+	}
+	type args struct {
+		defaultValue string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "Should be able to find actual UoM name in mapping by UBL key",
+			fields: fields{
+				items: map[string]*UoMItem{
+					"actual1": {
+						DefaultKey: "Act1",
+						MappedKey:  "Actual1",
+					},
+				},
+			},
+			args: args{
+				"Act1",
+			},
+			want: "Actual1",
+		},
+		{
+			name: "Should be empty result if there is no mapping for UBL key",
+			fields: fields{
+				items: map[string]*UoMItem{
+					"actual1": {
+						DefaultKey: "Act1",
+						MappedKey:  "Actual1",
+					},
+				},
+			},
+			args: args{
+				"Key1",
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &UoMMapConfig{
+				items: tt.fields.items,
+			}
+			if got := u.GetActualUoMValueByDefault(tt.args.defaultValue); got != tt.want {
+				t.Errorf("GetActualUoMValueByDefault() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUoMMapConfig_GetDefaultUoMValueByMapped(t *testing.T) {
+	type fields struct {
+		items map[string]*UoMItem
+	}
+	type args struct {
+		value string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "Should be found UBL-formatted key by actual UoM name",
+			fields: fields{
+				items: map[string]*UoMItem{
+					"act1": {
+						DefaultKey: "Actual 1",
+						MappedKey:  "Act 1",
+					},
+				},
+			},
+			args: args{
+				value: "Act1",
+			},
+			want: "Actual 1",
+		},
+		{
+			name: "Should be empty result if there is no known mapped value for UoM name",
+			fields: fields{
+				items: map[string]*UoMItem{
+					"act1": {
+						DefaultKey: "Actual 1",
+						MappedKey:  "Act 1",
+					},
+				},
+			},
+			args: args{
+				value: "Key1",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &UoMMapConfig{
+				items: tt.fields.items,
+			}
+			if got := u.GetDefaultUoMValueByMapped(tt.args.value); got != tt.want {
+				t.Errorf("GetDefaultUoMValueByMapped() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/productImport/ontologyValidator/attributesValidator.go
+++ b/productImport/ontologyValidator/attributesValidator.go
@@ -86,7 +86,7 @@ func (v *Validator) validateAttributesAgainstRules(
 							CategoryName: ruleCategory.Name,
 							AttrName:     attr.Name,
 							AttrValue:    reportAttribute.AttrValue,
-							UoM:          attr.MeasurementUoM,
+							UoM:          reportAttribute.UoM,
 							Errors:       message,
 							DataType:     fmt.Sprintf("%v", attr.DataType),
 							Description:  reportAttribute.Description,

--- a/productImport/reports/attributeReportBuilder.go
+++ b/productImport/reports/attributeReportBuilder.go
@@ -59,11 +59,19 @@ func (r *ReportsHandler) buildAttributesRaw(item Report) []string {
 		item.CategoryName,
 		item.AttrName,
 		item.AttrValue,
-		item.UoM,
+		r.getUoMActualMappedValue(item.UoM),
 		strings.Join(item.Errors, " "),
 		item.Description,
 		item.DataType,
 		item.IsMandatory,
 		item.CodedVal,
 	}
+}
+
+func (r *ReportsHandler) getUoMActualMappedValue(value string) string {
+	actualKey := r.UoMMapConfig.GetActualUoMValueByDefault(value)
+	if actualKey == "" {
+		return value
+	}
+	return actualKey
 }

--- a/productImport/reports/reportsHandler.go
+++ b/productImport/reports/reportsHandler.go
@@ -12,6 +12,7 @@ type ReportsHandler struct {
 	Handler           adapters.HandlerInterface
 	Header            *ReportLabels
 	ColumnMapConfig   *mapping.ColumnMapConfig
+	UoMMapConfig      *mapping.UoMMapConfig
 	productHandler    product.ProductHandlerInterface
 	SuccessResultPath string
 	FailResultPath    string
@@ -34,7 +35,8 @@ func NewReportsHandler(deps Deps) *ReportsHandler {
 	return &ReportsHandler{
 		Handler:           h,
 		productHandler:    deps.ProductHandler,
-		ColumnMapConfig:   m,
+		ColumnMapConfig:   deps.Mapping.GetColumnMapConfig(),
+		UoMMapConfig:      deps.Mapping.GetUoMMapConfig(),
 		Header:            initFailedAttributesReportHeader(m),
 		SuccessResultPath: conf.SuccessResultPath,
 		FailResultPath:    conf.ReportPath,

--- a/productImport/reports/successReportBuilder.go
+++ b/productImport/reports/successReportBuilder.go
@@ -13,8 +13,6 @@ const (
 	tsProductIdKey = "ID"
 )
 
-
-
 func (r *ReportsHandler) writeSuccessReport(report []Report, sourceData []map[string]interface{}, feedFilePath string) string {
 	filePath := filepath.Join(r.SuccessResultPath, buildSuccessFileName(feedFilePath))
 	var data [][]string
@@ -62,6 +60,11 @@ func (r *ReportsHandler) buildSuccessMapRaw(source []map[string]interface{}, rep
 				attr := findAttributeByName(attrName, productAttrs)
 				if attr != nil {
 					reportItem[i] = fmt.Sprintf("%v", attr.AttrValue)
+					if attr.UoM != "" {
+						if j, ok := headerIndex[buildUOMColumnName(attrName)]; ok {
+							reportItem[j] = r.getUoMDefaultMappedKey(attr.UoM)
+						}
+					}
 				} else {
 					reportItem[i] = fmt.Sprintf("%v", attrValue)
 				}
@@ -72,8 +75,8 @@ func (r *ReportsHandler) buildSuccessMapRaw(source []map[string]interface{}, rep
 			if i, ok := headerIndex[productAttrItem.AttrName]; ok {
 				reportItem[i] = fmt.Sprintf("%v", productAttrItem.AttrValue)
 				if productAttrItem.UoM != "" {
-					if j, ok := headerIndex[buildUOMColumnName(productAttrItem.Name)]; ok {
-						reportItem[j] = productAttrItem.UoM
+					if j, ok := headerIndex[buildUOMColumnName(productAttrItem.AttrName)]; ok {
+						reportItem[j] = r.getUoMDefaultMappedKey(productAttrItem.UoM)
 					}
 				}
 				if productAttrItem.Category != "" {
@@ -106,4 +109,12 @@ func findAttributeByName(attrName string, attributes []Report) *Report {
 		}
 	}
 	return nil
+}
+
+func (r *ReportsHandler) getUoMDefaultMappedKey(value string) string {
+	defaultKey := r.UoMMapConfig.GetDefaultUoMValueByMapped(value)
+	if defaultKey == "" {
+		return value
+	}
+	return defaultKey
 }

--- a/service.default.yaml
+++ b/service.default.yaml
@@ -6,6 +6,7 @@ product:
   report: ./data/result/report/
   success_result: ./data/result/sent/
   mapping: ./data/mapping/mapping.yaml
+  uom_mapping: ./data/mapping/uom_mapping.yaml
   ontology: ./data/ontology/rules.csv
 
 offer:


### PR DESCRIPTION
TS expects to get UOMs in UBL format.
So if sellers have it in a different format that they need to provide mapping on all used UOMs in their feeds.
We need to provide the possibility to apply this mapping and use it on the transformation.