### PR TITLE
TSAPPS-317 Add validation to UoM attribute

### DIFF
--- a/data/mapping/mapping.yaml
+++ b/data/mapping/mapping.yaml
@@ -7,3 +7,4 @@ column-mappings:
   ID: ID
   Category: Category
   Name: Name
+  UOM: UOM

--- a/productImport/mapping/columnMappingModel.go
+++ b/productImport/mapping/columnMappingModel.go
@@ -6,12 +6,14 @@ const (
 	categoryKey  = "Category" // TS min required column
 	productIdKey = "ID"       // TS min required
 	nameKey      = "Name"
+	UOMKey       = "UOM"
 )
 
 type ColumnMapConfig struct {
 	Category     string
 	ProductID    string
 	Name         string
+	UOM          string
 	OtherColumns []*ColumnItem
 }
 
@@ -41,6 +43,12 @@ func (m *mapping) NewColumnMap(rawMap map[string]string) *ColumnMapConfig {
 		parsedMap.Name = nameKey
 	}
 
+	if rawMap[UOMKey] != "" {
+		parsedMap.UOM = rawMap[UOMKey]
+	} else {
+		parsedMap.UOM = UOMKey
+	}
+
 	parsedMap.OtherColumns = parseNotRequiredColumns(rawMap)
 	return &parsedMap
 }
@@ -48,7 +56,7 @@ func (m *mapping) NewColumnMap(rawMap map[string]string) *ColumnMapConfig {
 func parseNotRequiredColumns(rawMap map[string]string) []*ColumnItem {
 	otherColumns := make([]*ColumnItem, 0)
 	for key, value := range rawMap {
-		if key != nameKey && key != productIdKey && key != categoryKey {
+		if key != nameKey && key != productIdKey && key != categoryKey && key != UOMKey {
 			otherColumns = append(
 				otherColumns,
 				&ColumnItem{
@@ -78,6 +86,13 @@ func (c *ColumnMapConfig) GetDefaultValueByMapped(mappedValue string) *ColumnIte
 		return &ColumnItem{
 			DefaultKey: nameKey,
 			MappedKey:  c.Name,
+		}
+	}
+
+	if utils.TrimAll(c.UOM) == utils.TrimAll(mappedValue) {
+		return &ColumnItem{
+			DefaultKey: UOMKey,
+			MappedKey:  c.UOM,
 		}
 	}
 

--- a/productImport/mapping/mapping.go
+++ b/productImport/mapping/mapping.go
@@ -54,11 +54,13 @@ func (m *mapping) readColumnMapping(mappingConfigPath string) {
 }
 
 func (m *mapping) initUoMapping() {
+	res := make([]*UoMItem, 0)
 	if m.uomMappingPath != "" {
 		if _, err := os.Stat(m.uomMappingPath); !os.IsNotExist(err) {
-			m.uomMap = NewUoMMapConfig(m.readUoMMapping(m.uomMappingPath))
+			res = m.readUoMMapping(m.uomMappingPath)
 		}
 	}
+	m.uomMap = NewUoMMapConfig(res)
 }
 
 func (m *mapping) readUoMMapping(uomPath string) []*UoMItem {

--- a/productImport/mapping/mapping_test.go
+++ b/productImport/mapping/mapping_test.go
@@ -15,23 +15,25 @@ func Test_mapping_Parse(t *testing.T) {
 		want   *ColumnMapConfig
 	}{
 		{
-			name: "positive: map should be converted to object with ProductID, Category and Name from relative columns",
+			name: "positive: map should be converted to object with ProductID, Category, UOM and Name from relative columns",
 			fields: fields{
 				rawMap: map[string]string{
 					"ID":       "Label1",
 					"Category": "Label2",
 					"Name":     "Label3",
+					"UOM":      "Label4",
 				},
 			},
 			want: &ColumnMapConfig{
 				ProductID:    "Label1",
 				Category:     "Label2",
 				Name:         "Label3",
+				UOM:          "Label4",
 				OtherColumns: []*ColumnItem{},
 			},
 		},
 		{
-			name: "positive: empty map should be converted to MAp Object with default values of ProductID, Category and Name",
+			name: "positive: empty map should be converted to Map Object with default values of ProductID, Category, UOM and Name",
 			fields: fields{
 				rawMap: nil,
 			},
@@ -39,6 +41,7 @@ func Test_mapping_Parse(t *testing.T) {
 				ProductID:    "ID",
 				Category:     "Category",
 				Name:         "Name",
+				UOM:          "UOM",
 				OtherColumns: []*ColumnItem{},
 			},
 		},

--- a/productImport/mapping/uomMappingModel.go
+++ b/productImport/mapping/uomMappingModel.go
@@ -10,7 +10,7 @@ type UoMItem struct {
 }
 
 type UoMMapConfig struct {
-	items map[string]*UoMItem
+	Items map[string]*UoMItem
 }
 
 func NewUoMMapConfig(items []*UoMItem) *UoMMapConfig {
@@ -19,19 +19,19 @@ func NewUoMMapConfig(items []*UoMItem) *UoMMapConfig {
 		res[utils.TrimAll(item.MappedKey)] = item
 	}
 	return &UoMMapConfig{
-		items: res,
+		Items: res,
 	}
 }
 
 func (u *UoMMapConfig) GetDefaultUoMValueByMapped(value string) string {
-	if res, ok := u.items[utils.TrimAll(value)]; ok {
+	if res, ok := u.Items[utils.TrimAll(value)]; ok {
 		return res.DefaultKey
 	}
 	return ""
 }
 
 func (u *UoMMapConfig) GetActualUoMValueByDefault(defaultValue string) string {
-	for _, u := range u.items {
+	for _, u := range u.Items {
 		if utils.TrimAll(defaultValue) == utils.TrimAll(u.DefaultKey) {
 			return u.MappedKey
 		}

--- a/productImport/mapping/uomMappingModel_test.go
+++ b/productImport/mapping/uomMappingModel_test.go
@@ -50,7 +50,7 @@ func TestUoMMapConfig_GetActualUoMValueByDefault(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			u := &UoMMapConfig{
-				items: tt.fields.items,
+				Items: tt.fields.items,
 			}
 			if got := u.GetActualUoMValueByDefault(tt.args.defaultValue); got != tt.want {
 				t.Errorf("GetActualUoMValueByDefault() = %v, want %v", got, tt.want)
@@ -106,7 +106,7 @@ func TestUoMMapConfig_GetDefaultUoMValueByMapped(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			u := &UoMMapConfig{
-				items: tt.fields.items,
+				Items: tt.fields.items,
 			}
 			if got := u.GetDefaultUoMValueByMapped(tt.args.value); got != tt.want {
 				t.Errorf("GetDefaultUoMValueByMapped() = %v, want %v", got, tt.want)

--- a/productImport/ontologyValidator/attributesValidator.go
+++ b/productImport/ontologyValidator/attributesValidator.go
@@ -41,6 +41,7 @@ func (v *Validator) validateAttributesAgainstRules(
 					if reportAttribute.AttrName == "" || (reportAttribute.AttrName != "" && reportAttribute.AttrName == attr.Name) {
 						if reportAttribute.AttrValue != "" {
 							//attrVal check type
+							// data type
 							if attr.DataType == rawOntology.FloatType || attr.DataType == rawOntology.NumberType {
 								_, err := utils.GetFloat(reportAttribute.AttrValue)
 								if err != nil {
@@ -59,12 +60,19 @@ func (v *Validator) validateAttributesAgainstRules(
 								}
 							}
 
+							//maxLength
 							if attr.MaxCharacterLength > 0 && len(reportAttribute.AttrValue) > attr.MaxCharacterLength {
 								message = append(
 									message,
 									"The attribute has a too long value (length: %v, max length: %v ).",
 									fmt.Sprintf("%v", len(reportAttribute.AttrValue)),
 									fmt.Sprintf("%v", attr.MaxCharacterLength))
+								isError = true
+							}
+
+							// units of measurement (UOM)
+							if isValid, errorMessage := v.isValidAttributeUoM(reportAttribute.UoM, attr); !isValid {
+								message = append(message, errorMessage)
 								isError = true
 							}
 

--- a/productImport/ontologyValidator/productsValidator.go
+++ b/productImport/ontologyValidator/productsValidator.go
@@ -89,6 +89,14 @@ func (v *Validator) validateProductsAgainstRules(
 								fmt.Sprintf("%v", attr.MaxCharacterLength))
 							isError = true
 						}
+						// units of measurement (UOM)
+						attrUOM, ok := prodToMapped[v.buildUomColumn(attr.Name)]
+						if ok {
+							if isValid, errorMessage := v.isValidAttributeUoM(attrUOM, attr); !isValid {
+								message = append(message, errorMessage)
+								isError = true
+							}
+						}
 
 						if len(message) == 0 {
 							message = append(message, "It is ok!")
@@ -112,7 +120,7 @@ func (v *Validator) validateProductsAgainstRules(
 						CategoryName: ruleCategory.Name,
 						AttrName:     attr.Name,
 						AttrValue:    val,
-						UoM:          attr.MeasurementUoM,
+						UoM:          prodToMapped[v.buildUomColumn(attr.Name)],
 						Errors:       message,
 						DataType:     fmt.Sprintf("%v", attr.DataType),
 						Description:  attr.Definition,
@@ -132,4 +140,8 @@ func (v *Validator) validateProductsAgainstRules(
 		}
 	}
 	return feed, isError
+}
+
+func (v Validator) buildUomColumn(attrName string) string {
+	return fmt.Sprintf("%s_%s", attrName, v.ColumnMap.UOM)
 }

--- a/productImport/ontologyValidator/rules.go
+++ b/productImport/ontologyValidator/rules.go
@@ -1,0 +1,24 @@
+package ontologyValidator
+
+import (
+	"fmt"
+	"ts/productImport/ontologyRead/models"
+	"ts/utils"
+)
+
+func (v *Validator) isValidAttributeUoM(actualUom string, attributeRule *models.AttributeConfig) (bool, string) {
+	if attributeRule.MeasurementUoM == "" {
+		return true, ""
+	}
+	defaultActualKey := v.uomMappingConfig.GetDefaultUoMValueByMapped(actualUom)
+	var uom string
+	if defaultActualKey == "" {
+		uom = actualUom
+	} else {
+		uom = defaultActualKey
+	}
+	if utils.TrimAll(uom) != utils.TrimAll(attributeRule.MeasurementUoM) {
+		return false, fmt.Sprintf("The attribute's UOM value should be '%v'", attributeRule.MeasurementUoM)
+	}
+	return true, ""
+}

--- a/productImport/ontologyValidator/rules_test.go
+++ b/productImport/ontologyValidator/rules_test.go
@@ -1,0 +1,180 @@
+package ontologyValidator
+
+import (
+	"testing"
+	"ts/logger"
+	"ts/productImport/mapping"
+	"ts/productImport/ontologyRead/models"
+	"ts/productImport/product"
+)
+
+func TestValidator_isValidAttributeUoM(t *testing.T) {
+	type fields struct {
+		logger           logger.LoggerInterface
+		productHandler   product.ProductHandlerInterface
+		ColumnMap        *ColumnMap
+		uomMappingConfig *mapping.UoMMapConfig
+	}
+	type args struct {
+		actualUom     string
+		attributeRule *models.AttributeConfig
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+		want1  string
+	}{
+		{
+			name: "Unmapped UOM considered as valid if it is equal to UOM from rules",
+			fields: fields{
+				ColumnMap: &ColumnMap{
+					UOM: "UOM",
+				},
+				uomMappingConfig: &mapping.UoMMapConfig{},
+			},
+			args: args{
+				actualUom: "kg",
+				attributeRule: &models.AttributeConfig{
+					MeasurementUoM: "Kg",
+				},
+			},
+			want:  true,
+			want1: "",
+		},
+		{
+			name: "Mapped UOM considered as valid if it's default key is equal to UOM from rules",
+			fields: fields{
+				ColumnMap: &ColumnMap{
+					UOM: "UOM",
+				},
+				uomMappingConfig: &mapping.UoMMapConfig{
+					Items: map[string]*mapping.UoMItem{
+						"kilo": {
+							DefaultKey: "KG",
+							MappedKey:  "KILO",
+						},
+					},
+				},
+			},
+			args: args{
+				actualUom: "Kilo",
+				attributeRule: &models.AttributeConfig{
+					MeasurementUoM: "Kg",
+				},
+			},
+			want:  true,
+			want1: "",
+		},
+		{
+			name: "Empty UOM considered as valid if UoM in rules was not defined",
+			fields: fields{
+				ColumnMap: &ColumnMap{
+					UOM: "UOM",
+				},
+				uomMappingConfig: &mapping.UoMMapConfig{},
+			},
+			args: args{
+				actualUom: "",
+				attributeRule: &models.AttributeConfig{
+					MeasurementUoM: "",
+				},
+			},
+			want:  true,
+			want1: "",
+		},
+		{
+			name: "Unmapped UOM considered as invalid if it is not equal to UOM from rules",
+			fields: fields{
+				ColumnMap: &ColumnMap{
+					UOM: "UOM",
+				},
+				uomMappingConfig: &mapping.UoMMapConfig{},
+			},
+			args: args{
+				actualUom: "pound",
+				attributeRule: &models.AttributeConfig{
+					MeasurementUoM: "Kg",
+				},
+			},
+			want:  false,
+			want1: "The attribute's UOM value should be 'Kg'",
+		},
+		{
+			name: "Mapped UOM considered as invalid if it's default key is not equal to UOM from rules",
+			fields: fields{
+				ColumnMap: &ColumnMap{
+					UOM: "UOM",
+				},
+				uomMappingConfig: &mapping.UoMMapConfig{
+					Items: map[string]*mapping.UoMItem{
+						"pounds": {
+							DefaultKey: "PN",
+							MappedKey:  "Pounds",
+						},
+					},
+				},
+			},
+			args: args{
+				actualUom: "Pounds",
+				attributeRule: &models.AttributeConfig{
+					MeasurementUoM: "Kg",
+				},
+			},
+			want:  false,
+			want1: "The attribute's UOM value should be 'Kg'",
+		},
+		{
+			name: "Empty UOM considered as invalid if UoM in rules was defined",
+			fields: fields{
+				ColumnMap: &ColumnMap{
+					UOM: "UOM",
+				},
+				uomMappingConfig: &mapping.UoMMapConfig{},
+			},
+			args: args{
+				actualUom: "",
+				attributeRule: &models.AttributeConfig{
+					MeasurementUoM: "Kg",
+				},
+			},
+			want:  false,
+			want1: "The attribute's UOM value should be 'Kg'",
+		},
+		{
+			name: "Not empty UOM considered as valid if UoM in rules was not defined",
+			fields: fields{
+				ColumnMap: &ColumnMap{
+					UOM: "UOM",
+				},
+				uomMappingConfig: &mapping.UoMMapConfig{},
+			},
+			args: args{
+				actualUom: "KG",
+				attributeRule: &models.AttributeConfig{
+					MeasurementUoM: "",
+				},
+			},
+			want:  true,
+			want1: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Validator{
+				logger:           tt.fields.logger,
+				productHandler:   tt.fields.productHandler,
+				ColumnMap:        tt.fields.ColumnMap,
+				uomMappingConfig: tt.fields.uomMappingConfig,
+			}
+			got, got1 := v.isValidAttributeUoM(tt.args.actualUom, tt.args.attributeRule)
+			if got != tt.want {
+				t.Errorf("isValidAttributeUoM() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("isValidAttributeUoM() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/productImport/ontologyValidator/validator.go
+++ b/productImport/ontologyValidator/validator.go
@@ -3,33 +3,38 @@ package ontologyValidator
 import (
 	"ts/logger"
 	"ts/productImport/attribute"
+	"ts/productImport/mapping"
 	"ts/productImport/ontologyRead/models"
 	"ts/productImport/product"
 	"ts/productImport/reports"
 )
 
 type Validator struct {
-	logger logger.LoggerInterface
-	productHandler product.ProductHandlerInterface
-	ColumnMap      *ColumnMap
+	logger           logger.LoggerInterface
+	productHandler   product.ProductHandlerInterface
+	ColumnMap        *ColumnMap
+	uomMappingConfig *mapping.UoMMapConfig
 }
 
 type ColumnMap struct {
 	Category  string
 	ProductID string
 	Name      string
+	UOM       string
 }
 
 func NewValidator(deps Deps) ValidatorInterface {
 	m := deps.Mapper.GetColumnMapConfig()
 	return &Validator{
-		logger: deps.Logger,
+		logger:         deps.Logger,
 		productHandler: deps.ProductHandler,
 		ColumnMap: &ColumnMap{
 			Category:  m.Category,
 			ProductID: m.ProductID,
 			Name:      m.Name,
+			UOM:       m.UOM,
 		},
+		uomMappingConfig: deps.Mapper.GetUoMMapConfig(),
 	}
 }
 

--- a/productImport/product/productHandler.go
+++ b/productImport/product/productHandler.go
@@ -20,6 +20,7 @@ func NewProductHandler(deps Deps) ProductHandlerInterface {
 			ProductID: m.ProductID,
 			Category:  m.Category,
 			Name:      m.Name,
+			UOM:       m.UOM,
 		},
 	}
 }

--- a/productImport/product/productHeader.go
+++ b/productImport/product/productHeader.go
@@ -9,6 +9,7 @@ type ProductColumnMap struct {
 	ProductID string
 	Category  string
 	Name      string
+	UOM       string
 }
 
 func (p *ProductHandler) GetCurrentHeader(row map[string]interface{}) *ProductColumnMap {
@@ -24,6 +25,8 @@ func (p *ProductHandler) GetCurrentHeader(row map[string]interface{}) *ProductCo
 			res.ProductID = key
 		case utils.TrimAll(columnMap.Name):
 			res.Name = key
+		case utils.TrimAll(columnMap.UOM):
+			res.UOM = key
 		}
 	}
 	return &res

--- a/productImport/reports/reportsHandler.go
+++ b/productImport/reports/reportsHandler.go
@@ -64,7 +64,6 @@ func initFailedAttributesReportHeader(m *mapping.ColumnMapConfig) *ReportLabels 
 		CategoryName: "Category Name",
 		AttrName:     "Attribute Name*",
 		AttrValue:    "Attribute Value*",
-		UoM:          "UOM",
 		Errors:       "Error Message",
 		Description:  "Description",
 		DataType:     "Data Type",
@@ -86,6 +85,11 @@ func initFailedAttributesReportHeader(m *mapping.ColumnMapConfig) *ReportLabels 
 		labels.Name = m.Name
 	} else {
 		labels.Name = "Name"
+	}
+	if m.UOM != "" {
+		labels.UoM = m.UOM
+	} else {
+		labels.UoM = "UOM"
 	}
 
 	return &labels


### PR DESCRIPTION
UOM (Units Of Measurements) in products and attributes file should be validated against the rules
UOM in source files (attributes, products) are mapped
In products UOM for attributes is in column "<attributeName>_UOM"
UOM column (attribute "UOM") in products should not be validated
If there is no rule for attribute's UOM, no need to validate it (we consider actual UOM as valid)
