### PR TITLE
TSAPPS-319 Fix validation behaviour

### DIFF
--- a/productImport/ontologyValidator/productsValidator.go
+++ b/productImport/ontologyValidator/productsValidator.go
@@ -90,7 +90,7 @@ func (v *Validator) validateProductsAgainstRules(
 							isError = true
 						}
 						// units of measurement (UOM)
-						attrUOM, ok := prodToMapped[v.buildUomColumn(attr.Name)]
+						attrUOM, ok := prodToMapped[v.buildUomColumn(mapping, attr.Name)]
 						if ok {
 							if isValid, errorMessage := v.isValidAttributeUoM(attrUOM, attr); !isValid {
 								message = append(message, errorMessage)
@@ -120,7 +120,7 @@ func (v *Validator) validateProductsAgainstRules(
 						CategoryName: ruleCategory.Name,
 						AttrName:     attr.Name,
 						AttrValue:    val,
-						UoM:          prodToMapped[v.buildUomColumn(attr.Name)],
+						UoM:          prodToMapped[v.buildUomColumn(mapping, attr.Name)],
 						Errors:       message,
 						DataType:     fmt.Sprintf("%v", attr.DataType),
 						Description:  attr.Definition,
@@ -142,6 +142,16 @@ func (v *Validator) validateProductsAgainstRules(
 	return feed, isError
 }
 
-func (v Validator) buildUomColumn(attrName string) string {
-	return fmt.Sprintf("%s_%s", attrName, v.ColumnMap.UOM)
+func (v Validator) buildUomColumn(mapping map[string]string, attrName string) string {
+	attrName = strings.Replace(attrName, "  ", " ", -1)
+	attrName = strings.TrimLeft(attrName, " ")
+	attrName = strings.TrimRight(attrName, " ")
+
+	var columnName string
+	if value, ok := mapping[attrName]; ok {
+		columnName = value
+	} else {
+		columnName = attrName
+	}
+	return fmt.Sprintf("%s_UOM", columnName)
 }

--- a/productImport/ontologyValidator/productsValidator_test.go
+++ b/productImport/ontologyValidator/productsValidator_test.go
@@ -1,0 +1,64 @@
+package ontologyValidator
+
+import (
+	"testing"
+	"ts/logger"
+	"ts/productImport/mapping"
+	"ts/productImport/product"
+)
+
+func TestValidator_buildUomColumn(t *testing.T) {
+	type fields struct {
+		logger           logger.LoggerInterface
+		productHandler   product.ProductHandlerInterface
+		ColumnMap        *ColumnMap
+		uomMappingConfig *mapping.UoMMapConfig
+	}
+	type args struct {
+		mapping  map[string]string
+		attrName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name:   "mapped value should be returned if column has mapping",
+			fields: fields{},
+			args: args{
+				mapping: map[string]string{
+					"Default": "Actual",
+				},
+				attrName: "Actual",
+			},
+			want: "Actual_UOM",
+		},
+
+		{
+			name:   "unmapped value should be returned if there is no mapping for column",
+			fields: fields{},
+			args: args{
+				mapping: map[string]string{
+					"Seno": "Soloma",
+				},
+				attrName: "Actual",
+			},
+			want: "Actual_UOM",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := Validator{
+				logger:           tt.fields.logger,
+				productHandler:   tt.fields.productHandler,
+				ColumnMap:        tt.fields.ColumnMap,
+				uomMappingConfig: tt.fields.uomMappingConfig,
+			}
+			if got := v.buildUomColumn(tt.args.mapping, tt.args.attrName); got != tt.want {
+				t.Errorf("buildUomColumn() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/productImport/ontologyValidator/rules.go
+++ b/productImport/ontologyValidator/rules.go
@@ -10,14 +10,7 @@ func (v *Validator) isValidAttributeUoM(actualUom string, attributeRule *models.
 	if attributeRule.MeasurementUoM == "" {
 		return true, ""
 	}
-	defaultActualKey := v.uomMappingConfig.GetDefaultUoMValueByMapped(actualUom)
-	var uom string
-	if defaultActualKey == "" {
-		uom = actualUom
-	} else {
-		uom = defaultActualKey
-	}
-	if utils.TrimAll(uom) != utils.TrimAll(attributeRule.MeasurementUoM) {
+	if utils.TrimAll(actualUom) != utils.TrimAll(attributeRule.MeasurementUoM) {
 		return false, fmt.Sprintf("The attribute's UOM value should be '%v'", attributeRule.MeasurementUoM)
 	}
 	return true, ""

--- a/productImport/ontologyValidator/rules_test.go
+++ b/productImport/ontologyValidator/rules_test.go
@@ -44,30 +44,6 @@ func TestValidator_isValidAttributeUoM(t *testing.T) {
 			want1: "",
 		},
 		{
-			name: "Mapped UOM considered as valid if it's default key is equal to UOM from rules",
-			fields: fields{
-				ColumnMap: &ColumnMap{
-					UOM: "UOM",
-				},
-				uomMappingConfig: &mapping.UoMMapConfig{
-					Items: map[string]*mapping.UoMItem{
-						"kilo": {
-							DefaultKey: "KG",
-							MappedKey:  "KILO",
-						},
-					},
-				},
-			},
-			args: args{
-				actualUom: "Kilo",
-				attributeRule: &models.AttributeConfig{
-					MeasurementUoM: "Kg",
-				},
-			},
-			want:  true,
-			want1: "",
-		},
-		{
 			name: "Empty UOM considered as valid if UoM in rules was not defined",
 			fields: fields{
 				ColumnMap: &ColumnMap{


### PR DESCRIPTION
Fixed cases:
- 'UOM' suffix of _UOM attribute should be always 'UOM' (without mapping)
- Attribute's name in _UOM attribute should be mapped
- Rules and products/attributes data should be in same format (no need to translate it to UBL to compare)